### PR TITLE
fix: remove node package install from launch

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -62,11 +62,6 @@ if [ "$1" = "--build-engines" ]; then
   shift
 fi
 
-# Install npm packages if needed
-cd /workspace/comfystream/ui
-if [ ! -d "node_modules" ]; then
-  npm install --legacy-peer-deps
-fi
 
 if [ "$1" = "--server" ]; then
   /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
This resolved an error with the `livepeer/comfystream:latest` image unable to start due to missing ui folder. The ui folder is not used in the image any longer, so it can be removed