### PR TITLE
fix: add librosa

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "toml",
     "twilio",
     "prometheus_client",
+    "librosa"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiohttp
 toml
 twilio
 prometheus_client
+librosa


### PR DESCRIPTION
Adds the `librosa` package as a requirement for `audio_utils` nodes which were added in https://github.com/yondonfu/comfystream/pull/163

This change also removes `requirements.txt` in favor of the newer `pyproject.toml` for package management. This will install dependencies via setup tools when package is installed.