### PR TITLE
fix: disable sam-2 node in base image

### DIFF
--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -39,11 +39,11 @@ nodes:
     url: "https://github.com/ad-astra-video/ComfyUI-Florence2-Vision.git"
     type: "vision"
    
-  comfyui-sam2-realtime:
-    name: "ComfyUI SAM2 Realtime"
-    branch: "main"
-    url: "https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git"
-    type: "vision"
+  # comfyui-sam2-realtime:
+  #   name: "ComfyUI SAM2 Realtime"
+  #   branch: "main"
+  #   url: "https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git"
+  #   type: "vision"
 
   comfyui-load-image-url:
     name: "ComfyUI Load Image from URL"


### PR DESCRIPTION
Due to an issue with the SAM-2 node, temporarily disabling to unblock builds