### PR TITLE
workflows: Build more of comfyui-base docker image

### DIFF
--- a/.github/workflows/comfyui-base.yaml
+++ b/.github/workflows/comfyui-base.yaml
@@ -2,19 +2,13 @@ name: Build and push comfyui-base docker image
 
 on:
   pull_request:
-    paths:
-      - docker/Dockerfile.base
-      - src/comfystream/scripts/
-      - configs/
-      - .github/workflows/comfyui-base.yaml
+    paths-ignore:
+      - "ui/*"
     branches:
       - main
   push:
-    paths:
-      - docker/Dockerfile.base
-      - src/comfystream/scripts/
-      - configs/
-      - .github/workflows/comfyui-base.yaml
+    paths-ignore:
+      - "ui/*"
     branches:
       - main
     tags:


### PR DESCRIPTION
to avoid cases like this in future: https://discord.com/channels/423160867534929930/1347089824644993067/1354841329363849457

i'm not sure if `ui/` files are needed for the base docker image. open to removing the `paths` and `paths-ignore` entirely and just build the base-image for all PRs if that's more useful/makes sense.