### PR TITLE
fix: revert conda env activation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 ARG	BASE_IMAGE=livepeer/comfyui-base:latest
 
 FROM	${BASE_IMAGE}
+RUN unset BASH_ENV
 
 ENV	PATH="/workspace/miniconda3/bin:${PATH}" \
 	NVM_DIR=/root/.nvm \


### PR DESCRIPTION
The BASH_ENV variable prevented env deactivation and can caused pip issues, this reverts to the prior behavior from https://github.com/livepeer/comfystream/pull/56/commits/9f49aca9b552791755ce7ee89aa59fa3b63c91bc