### PR TITLE
disable automatic env activation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 				"python.defaultInterpreterPath": "/workspace/miniconda3/envs/comfystream/bin/python",
 				"python.venvPath": "/workspace/miniconda3/envs",
 				"python.terminal.activateEnvInCurrentTerminal": false,
-				"python.terminal.activateEnvironment": true,
+				"python.terminal.activateEnvironment": false,
 				"terminal.integrated.shellIntegration.enabled": true
 			},
 			"extensions": [


### PR DESCRIPTION
This change disables automatic env activation in devcontainer.json since all bash shell sessions are already activated with comfystream as the default environment