### PR TITLE
attempt to fix docker build

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -14,12 +14,14 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # System dependencies
 RUN apt update && apt install -yqq \
+    build-essential \
+    libc6 \
     git \
     wget \
     nano \
     socat \
     libsndfile1 \
-    build-essential llvm tk-dev && \
+    llvm tk-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Conda setup


### PR DESCRIPTION
Our docker builds suspiciously broke after removing `gpu` as the runner type. Adding libc6 to the image in attempt to solve