### PR TITLE
add workflow to publish to registry

### DIFF
--- a/.github/workflows/publish-comfyui-node.yaml
+++ b/.github/workflows/publish-comfyui-node.yaml
@@ -1,0 +1,26 @@
+name: Publish ComfyUI Custom Node
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  publish-comfyui-node:
+    name: Publish Custom Node to ComfyUI registry
+    runs-on: ubuntu-latest
+    # Ensure this only runs on main branch
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Publish Custom Node
+        uses: Comfy-Org/publish-node-action@v1
+        with:
+          ## Add your own personal access token to your Github Repository secrets and reference it here.
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Create ui-kit release artifact
+name: Create ui-kit release artifact and publish to ComfyUI registry
 
 on:
   push:
@@ -6,6 +6,9 @@ on:
       - main
     tags:
       - "v*"
+
+permissions:
+  issues: write
 
 jobs:
   release:
@@ -50,3 +53,19 @@ jobs:
           files: ${{ steps.build.outputs.dist_file }}
           make_latest: true
           generate_release_notes: true
+
+  publish-comfyui-node:
+    name: Publish Custom Node to ComfyUI registry
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_type == 'tag' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Publish Custom Node
+        uses: Comfy-Org/publish-node-action@v1
+        with:
+          ## Add your own personal access token to your Github Repository secrets and reference it here.
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,11 @@
 name: Create ui-kit release artifact and publish to ComfyUI registry
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   issues: write
@@ -57,7 +58,7 @@ jobs:
   publish-comfyui-node:
     name: Publish Custom Node to ComfyUI registry
     runs-on: ubuntu-latest
-    if: ${{ github.ref_type == 'tag' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,6 @@
 name: Create ui-kit release artifact and publish to ComfyUI registry
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Create ui-kit release artifact and publish to ComfyUI registry
+name: Create ui-kit release artifact
 
 on:
   push:
@@ -6,10 +6,6 @@ on:
       - main
     tags:
       - "v*"
-  workflow_dispatch:
-
-permissions:
-  issues: write
 
 jobs:
   release:
@@ -54,19 +50,3 @@ jobs:
           files: ${{ steps.build.outputs.dist_file }}
           make_latest: true
           generate_release_notes: true
-
-  publish-comfyui-node:
-    name: Publish Custom Node to ComfyUI registry
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Publish Custom Node
-        uses: Comfy-Org/publish-node-action@v1
-        with:
-          ## Add your own personal access token to your Github Repository secrets and reference it here.
-          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}


### PR DESCRIPTION
This pull request updates the release workflow to enable publishing custom nodes to the ComfyUI registry when a new release tag is pushed. The changes also introduce additional permissions needed for publishing and add a new job to handle the publishing process.

**Release workflow enhancements:**

* Updated the workflow name in `.github/workflows/release.yaml` to reflect both artifact creation and publishing to the ComfyUI registry.
* Added `issues: write` permission to the workflow to support publishing actions.

**Publishing automation:**

* Added a new `publish-comfyui-node` job to `.github/workflows/release.yaml` that runs on tagged releases, checks out the code, and publishes the custom node to the ComfyUI registry using the `Comfy-Org/publish-node-action@v1` GitHub Action. The job uses a personal access token from repository secrets for authentication.