### PR TITLE
rename temporary_log_level to set_temporary_log_level

### DIFF
--- a/src/comfystream/__init__.py
+++ b/src/comfystream/__init__.py
@@ -1,6 +1,6 @@
 from .client import ComfyStreamClient
 from .pipeline import Pipeline
-from .server.utils import temporary_log_level
+from .server.utils import set_temporary_log_level
 from .server.app import VideoStreamTrack, AudioStreamTrack
 from .server.utils import FPSMeter
 from .server.metrics import MetricsManager, StreamStatsManager

--- a/src/comfystream/pipeline.py
+++ b/src/comfystream/pipeline.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Dict, Union, List, Optional
 
 from comfystream.client import ComfyStreamClient
-from comfystream.server.utils import temporary_log_level
+from comfystream.server.utils import set_temporary_log_level
 
 WARMUP_RUNS = 5
 
@@ -163,7 +163,7 @@ class Pipeline:
         Returns:
             The processed video frame
         """
-        async with temporary_log_level("comfy", self._comfyui_inference_log_level):
+        async with set_temporary_log_level("comfy", self._comfyui_inference_log_level):
             out_tensor = await self.client.get_video_output()
         frame = await self.video_incoming_frames.get()
         while frame.side_data.skipped:
@@ -183,7 +183,7 @@ class Pipeline:
         """
         frame = await self.audio_incoming_frames.get()
         if frame.samples > len(self.processed_audio_buffer):
-            async with temporary_log_level("comfy", self._comfyui_inference_log_level):
+            async with set_temporary_log_level("comfy", self._comfyui_inference_log_level):
                 out_tensor = await self.client.get_audio_output()
             self.processed_audio_buffer = np.concatenate([self.processed_audio_buffer, out_tensor])
         out_data = self.processed_audio_buffer[:frame.samples]

--- a/src/comfystream/server/utils/__init__.py
+++ b/src/comfystream/server/utils/__init__.py
@@ -1,2 +1,2 @@
-from .utils import patch_loop_datagram, add_prefix_to_app_routes, temporary_log_level
+from .utils import patch_loop_datagram, add_prefix_to_app_routes, set_temporary_log_level
 from .fps_meter import FPSMeter

--- a/src/comfystream/server/utils/utils.py
+++ b/src/comfystream/server/utils/utils.py
@@ -67,7 +67,7 @@ def add_prefix_to_app_routes(app: web.Application, prefix: str):
 
 
 @asynccontextmanager
-async def temporary_log_level(logger_name: str, level: int):
+async def set_temporary_log_level(logger_name: str, level: int):
     """Temporarily set the log level of a logger.
 
     Args:


### PR DESCRIPTION
Improves the naming convention for temporary_log_level since it is exported, makes package easier to understand