### PR TITLE
fix: exclude app.py from exported server package, add torch init

### DIFF
--- a/nodes/server_manager.py
+++ b/nodes/server_manager.py
@@ -148,7 +148,7 @@ class LocalComfyStreamServer(ComfyStreamServerBase):
                 self.host = host
             
             # Get the path to the ComfyStream server directory and script
-            server_dir = Path(__file__).parent.parent / "src" / "comfystream" / "server"
+            server_dir = Path(__file__).parent.parent / "server"
             server_script = server_dir / "app.py"
             logging.info(f"Server script: {server_script}")
             

--- a/server/app.py
+++ b/server/app.py
@@ -4,6 +4,11 @@ import json
 import logging
 import os
 import sys
+import torch
+
+# Initialize CUDA before any other imports to prevent core dump.
+if torch.cuda.is_available():
+    torch.cuda.init()
 
 from aiohttp import web
 from aiortc import (

--- a/src/comfystream/__init__.py
+++ b/src/comfystream/__init__.py
@@ -1,7 +1,6 @@
 from .client import ComfyStreamClient
 from .pipeline import Pipeline
 from .server.utils import temporary_log_level
-from .server.app import VideoStreamTrack, AudioStreamTrack
 from .server.utils import FPSMeter
 from .server.metrics import MetricsManager, StreamStatsManager
 
@@ -9,8 +8,6 @@ __all__ = [
     'ComfyStreamClient',
     'Pipeline',
     'temporary_log_level',
-    'VideoStreamTrack',
-    'AudioStreamTrack',
     'FPSMeter',
     'MetricsManager',
     'StreamStatsManager'


### PR DESCRIPTION
This is a fix for #114 to resolve an issue with app.py running during package import. By moving app.py back to `server/app.py` it is excluded from the comfystream package, allowing `torch.init()` to be added back. 