### PR TITLE
qualify volume mount copy with --server flag

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,17 +3,19 @@
 set -e
 eval "$(conda shell.bash hook)"
 
-# Handle workspace mounting
-if [ -d "/app" ] && [ ! -d "/app/miniconda3" ]; then
-  echo "Initializing workspace in /app..."
-  cp -r /workspace/* /app
-fi
+if [ "$1" = "--server" ]; then
+  # Handle workspace mounting
+  if [ -d "/app" ] && [ ! -d "/app/miniconda3" ]; then
+    echo "Initializing workspace in /app..."
+    cp -r /workspace/* /app
+  fi
 
-if [ -d "/app" ] && [ ! -L "/workspace" ]; then
-  echo "Starting from volume mount /app..."
-  cd / && rm -rf /workspace
-  ln -sf /app /workspace
-  cd /workspace/comfystream
+  if [ -d "/app" ] && [ ! -L "/workspace" ]; then
+    echo "Starting from volume mount /app..."
+    cd / && rm -rf /workspace
+    ln -sf /app /workspace
+    cd /workspace/comfystream
+  fi
 fi
 
 # Add help command to show usage


### PR DESCRIPTION
This change resolves #10 by qualifying this block of code in `entrypoint.sh` with the `--server` flag to prevent it from running automatically in ai-runner when calling entrypoint.sh (there are common dev uses for calling this script)

https://github.com/livepeer/comfystream/blob/fccc12bf372fd95a02ed00b65ec3f6cc4fc19dfe/docker/entrypoint.sh#L6-L19