### PR TITLE
fix: build static ui files for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,4 @@
 .git/
 .venv/
 .github/
-ui/
 .dockerignore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,9 +25,16 @@ ENV	NODE_PATH="$NVM_DIR/v$NODE_VERSION/lib/node_modules" \
 
 # Create the supervisor configuration file for ComfyUI and ComfyStream
 COPY	docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY    --chmod=0755	docker/entrypoint.sh /workspace/comfystream/docker/entrypoint.sh
+
+WORKDIR	/workspace/comfystream/ui
+RUN npm install
+RUN	npm run build
+
+# Restore .gitkeep file after ui build for devcontainer users
+RUN touch /workspace/comfystream/nodes/web/static/.gitkeep
 
 WORKDIR	/workspace/comfystream
-COPY --chmod=0755	docker/entrypoint.sh /workspace/comfystream/docker/entrypoint.sh
 
 EXPOSE	8188	8889	3000
 EXPOSE	1024-65535/udp


### PR DESCRIPTION
This change ensures the static UI files are built with each `livepeer/comfystream` docker image:
- Adds the `ui` folder to comfyui-base
- Installs npm dependencies in `/workspace/comfystream/ui`
- Build the UI static files for each comfystream docker build

The current [github action](https://github.com/livepeer/comfystream/blob/main/.github/workflows/release.yaml) to build the UI only runs when tagging releases, so it doesn't work for reviewing UI changes. The comfystream [install](https://github.com/livepeer/comfystream/blob/feat/ui-build-docker/install.py) script only downloads UI files by version tag.