### PR TITLE
improve volume mount for persistent storage

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,26 +3,12 @@
 set -e
 eval "$(conda shell.bash hook)"
 
-if [ "$1" = "--server" ]; then
-  # Handle workspace mounting
-  if [ -d "/app" ] && [ ! -d "/app/miniconda3" ]; then
-    echo "Initializing workspace in /app..."
-    cp -r /workspace/* /app
-  fi
-
-  if [ -d "/app" ] && [ ! -L "/workspace" ]; then
-    echo "Starting from volume mount /app..."
-    cd / && rm -rf /workspace
-    ln -sf /app /workspace
-    cd /workspace/comfystream
-  fi
-fi
-
 # Add help command to show usage
 show_help() {
   echo "Usage: entrypoint.sh [OPTIONS]"
   echo ""
   echo "Options:"
+  echo "  --persistent-volume     Initialize persistent volume mount"
   echo "  --download-models       Download default models"
   echo "  --build-engines         Build TensorRT engines for default models"
   echo "  --opencv-cuda           Setup OpenCV with CUDA support"
@@ -34,6 +20,31 @@ show_help() {
 if [ "$1" = "--help" ]; then
   show_help
   exit 0
+fi
+
+# Define reusable paths
+WORKSPACE_STORAGE="/workspace/storage"
+COMFYUI_DIR="/workspace/ComfyUI"
+MODELS_DIR="$COMFYUI_DIR/models"
+OUTPUT_DIR="$COMFYUI_DIR/output"
+
+# Map persistent volume mount for models and engines using symlinks
+if [ "$1" = "--persistent-volume" ] && [ -d "$WORKSPACE_STORAGE" ]; then
+  echo "Initializing persistent volume mount..."
+  if [ ! -L "$MODELS_DIR" ]; then
+      ln -s $WORKSPACE_STORAGE/models "$MODELS_DIR"
+      echo "created symlink for models at $MODELS_DIR"
+  else
+      echo "symlink for models already exists at $MODELS_DIR"
+  fi
+
+  if [ ! -L "$OUTPUT_DIR" ]; then
+      ln -s $WORKSPACE_STORAGE/output "$OUTPUT_DIR"
+      echo "created symlink for output at $OUTPUT_DIR"
+  else
+      echo "symlink for output already exists at $OUTPUT_DIR"
+  fi
+  shift
 fi
 
 if [ "$1" = "--download-models" ]; then


### PR DESCRIPTION
Improves persistent volume mounting by storing only models and engines on the persistent mount. 

This eliminates the long startup overhead when deploying with a volume mount on RunPod. It also ensures the volume can be used with newer docker comfystream images.

- Solves for the dual mount problem using symlinks which are only set on startup when the `--persist-data` flag is used. 
- Links are only created if directories are not already links to prevent data loss
- Data is no longer copied, engines are compiled at the same paths, mounted as volume or not

