### PR TITLE
fix: pin onnx 1.17.0 due to breaking changes in 1.18.0

### DIFF
--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -7,7 +7,7 @@ nodes:
     type: "tensorrt"
     dependencies: 
       - "onnxruntime-gpu>=1.17.0"
-      - "onnx>=1.17.0"
+      - "onnx==1.17.0"
 
   comfyui-depthanything-tensorrt:
     name: "ComfyUI DepthAnything TensorRT"


### PR DESCRIPTION
This resolves an issue compiling tensorrt engines by pinning `onnx==1.17.0`

Recent builds have been breaking on engine compilation due to onnx version 1.18.0. Downgrading to 1.17.0 resolved the issue. There appear to be breaking changes between `onnx==1.18.0` and `onnxmltools 1.13.0`.

For reference `conda list | grep onnx` returns in each env before/after:
- Broken with 1.18.0
![image](https://github.com/user-attachments/assets/5226e722-dc4c-48b3-8d63-7d0b96b17103)
- Working with 1.17.0
![image](https://github.com/user-attachments/assets/30b25a0a-5273-47d7-a897-93dc11ef9f55)


https://github.com/onnx/onnxmltools/issues/712#issuecomment-2875074679

```
demo-comfystream  | Models download completed!
demo-comfystream  | __init__.py already exists at /workspace/ComfyUI/__init__.py
demo-comfystream  | __init__.py already exists at /workspace/ComfyUI/comfy/__init__.py
demo-comfystream  | __init__.py already exists at /workspace/ComfyUI/comfy_extras/__init__.py
demo-comfystream  | Traceback (most recent call last):
demo-comfystream  |   File "/workspace/comfystream/src/comfystream/scripts/build_trt.py", line 47, in <module>
demo-comfystream  |     from ComfyUI.custom_nodes.ComfyUI_TensorRT.models.supported_models import detect_version_from_model, get_helper_from_model
demo-comfystream  |   File "/workspace/ComfyUI/custom_nodes/ComfyUI_TensorRT/__init__.py", line 3, in <module>
demo-comfystream  |     from .onnx_nodes import NODE_CLASS_MAPPING as ONNX_CLASS_MAP
demo-comfystream  |   File "/workspace/ComfyUI/custom_nodes/ComfyUI_TensorRT/onnx_nodes.py", line 6, in <module>
demo-comfystream  |     from .onnx_utils.export import export_onnx
demo-comfystream  |   File "/workspace/ComfyUI/custom_nodes/ComfyUI_TensorRT/onnx_utils/export.py", line 15, in <module>
demo-comfystream  |     from onnxmltools.utils.float16_converter import convert_float_to_float16
demo-comfystream  |   File "/workspace/miniconda3/envs/comfystream/lib/python3.11/site-packages/onnxmltools/__init__.py", line 25, in <module>
demo-comfystream  |     from .utils import load_model
demo-comfystream  |   File "/workspace/miniconda3/envs/comfystream/lib/python3.11/site-packages/onnxmltools/utils/__init__.py", line 3, in <module>
demo-comfystream  |     from .main import load_model
demo-comfystream  |   File "/workspace/miniconda3/envs/comfystream/lib/python3.11/site-packages/onnxmltools/utils/main.py", line 4, in <module>
demo-comfystream  |     from ..proto import onnx_proto
demo-comfystream  |   File "/workspace/miniconda3/envs/comfystream/lib/python3.11/site-packages/onnxmltools/proto/__init__.py", line 14, in <module>
demo-comfystream  |     from onnx.helper import split_complex_to_pairs
demo-comfystream  | ImportError: cannot import name 'split_complex_to_pairs' from 'onnx.helper' (/workspace/miniconda3/envs/comfystream/lib/python3.11/site-packages/onnx/helper.py)
demo-comfystream exited with code 1
```
