### PR TITLE
feat: add toggle for Prometheus metrics server

### DIFF
--- a/nodes/api/__init__.py
+++ b/nodes/api/__init__.py
@@ -90,6 +90,7 @@ if hasattr(PromptServer.instance, 'routes') and hasattr(PromptServer.instance.ro
             # Extract host and port from settings if provided
             host = settings.get("host") if settings else None
             port = settings.get("port") if settings else None
+            enable_metrics = settings.get("enableMetrics") if settings else None
             
             if action == "status":
                 # Simply return the current server status
@@ -98,7 +99,11 @@ if hasattr(PromptServer.instance, 'routes') and hasattr(PromptServer.instance.ro
                     "status": server_manager.get_status()
                 })
             elif action == "start":
-                success = await server_manager.start(port=port, host=host)
+                success = await server_manager.start(
+                    port=port,
+                    host=host,
+                    enable_metrics=enable_metrics
+                )
                 return web.json_response({
                     "success": success,
                     "status": server_manager.get_status()
@@ -120,7 +125,11 @@ if hasattr(PromptServer.instance, 'routes') and hasattr(PromptServer.instance.ro
                         "message": "Forced server shutdown due to error"
                     })
             elif action == "restart":
-                success = await server_manager.restart(port=port, host=host)
+                success = await server_manager.restart(
+                    port=port,
+                    host=host,
+                    enable_metrics=enable_metrics
+                )
                 return web.json_response({
                     "success": success,
                     "status": server_manager.get_status()
@@ -178,10 +187,16 @@ if hasattr(PromptServer.instance, 'routes') and hasattr(PromptServer.instance.ro
                 name = data.get("name")
                 host = data.get("host")
                 port = data.get("port")
+                enable_metrics = data.get("enableMetrics")
                 if not name or not host or not port:
                     return web.json_response({"error": "Missing required parameters"}, status=400)
                 
-                success = settings_storage.add_configuration(name, host, port)
+                success = settings_storage.add_configuration(
+                    name, 
+                    host, 
+                    port, 
+                    enable_metrics
+                )
                 return web.json_response({
                     "success": success,
                     "settings": settings_storage.load_settings()
@@ -214,4 +229,3 @@ if hasattr(PromptServer.instance, 'routes') and hasattr(PromptServer.instance.ro
         except Exception as e:
             logging.error(f"Error managing configuration: {str(e)}")
             return web.json_response({"error": str(e)}, status=500)
-

--- a/nodes/settings_storage.py
+++ b/nodes/settings_storage.py
@@ -15,6 +15,7 @@ logging.basicConfig(
 DEFAULT_SETTINGS = {
     "host": "0.0.0.0",
     "port": 8889,
+    "enableMetrics": False,
     "configurations": [],
     "selectedConfigIndex": -1
 }
@@ -78,12 +79,17 @@ def update_settings(new_settings):
     
     return save_settings(current_settings)
 
-def add_configuration(name, host, port):
+def add_configuration(name, host, port, enable_metrics):
     """Add a new configuration"""
     settings = load_settings()
     
     # Create the new configuration
-    config = {"name": name, "host": host, "port": port}
+    config = {
+        "name": name,
+        "host": host,
+        "port": port,
+        "enableMetrics": enable_metrics
+    }
     
     # Add to configurations list
     settings["configurations"].append(config)
@@ -125,6 +131,7 @@ def select_configuration(index):
             config = settings["configurations"][index]
             settings["host"] = config["host"]
             settings["port"] = config["port"]
+            settings["enableMetrics"] = config["enableMetrics"]
         
         # Save updated settings
         return save_settings(settings)

--- a/nodes/web/js/launcher.js
+++ b/nodes/web/js/launcher.js
@@ -101,7 +101,7 @@ document.addEventListener('comfy-extension-registered', (event) => {
 async function controlServer(action) {
     try {
         // Get settings from the settings manager
-        const settings = settingsManager.getCurrentHostPort();
+        const settings = settingsManager.getCurrentServerSettings();
         
         // Set transitional state based on action
         if (action === 'start') {

--- a/settings/comfystream_settings.json
+++ b/settings/comfystream_settings.json
@@ -5,13 +5,16 @@
     {
       "name": "RunPod",
       "host": "0.0.0.0",
-      "port": 8889
+      "port": 8889,
+      "enableMetrics": false
     },
     {
       "name": "Localhost",
       "host": "localhost",
-      "port": 8889
+      "port": 8889,
+      "enableMetrics": false
     }
   ],
-  "selectedConfigIndex": 1
+  "selectedConfigIndex": 1,
+  "enableMetrics": false
 }


### PR DESCRIPTION
This pull request introduces a new configuration option in the ComfyUI settings to enable or disable the ComfyStream Prometheus metrics server. It also adds tooltips to existing configuration options to enhance user guidance.

@eliteprox While the server successfully starts the metrics endpoint at `https://localhost:8889/metrics`, I'm unable to access it via the browser. However, this appears to be a separate issue, as the `streams` endpoint is also inaccessible.