### PR TITLE
add opengl egl support on nvidia gpu

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,9 +8,18 @@ ENV	PATH="/workspace/miniconda3/bin:${PATH}" \
 
 RUN	echo "Using base image: ${BASE_IMAGE}" && \
 	apt update && \
-	apt install -yqq supervisor && \
+	apt install -yqq supervisor libglvnd-dev && \
 	wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
+#enable opengl support with nvidia gpu
+RUN printf '%s\n' \
+  '{' \
+  '    "file_format_version" : "1.0.0",' \
+  '    "ICD" : {' \
+  '        "library_path" : "libEGL_nvidia.so.0"' \
+  '    }' \
+  '}' > /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+  
 WORKDIR	/
 
 # Install node and npm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,18 +8,9 @@ ENV	PATH="/workspace/miniconda3/bin:${PATH}" \
 
 RUN	echo "Using base image: ${BASE_IMAGE}" && \
 	apt update && \
-	apt install -yqq supervisor libglvnd-dev && \
+	apt install -yqq supervisor && \
 	wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
-#enable opengl support with nvidia gpu
-RUN printf '%s\n' \
-  '{' \
-  '    "file_format_version" : "1.0.0",' \
-  '    "ICD" : {' \
-  '        "library_path" : "libEGL_nvidia.so.0"' \
-  '    }' \
-  '}' > /usr/share/glvnd/egl_vendor.d/10_nvidia.json
-  
 WORKDIR	/
 
 # Install node and npm

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -19,8 +19,19 @@ RUN apt update && apt install -yqq \
     nano \
     socat \
     libsndfile1 \
-    build-essential llvm tk-dev && \
+    build-essential \
+    llvm tk-dev \
+    libglvnd-dev && \
     rm -rf /var/lib/apt/lists/*
+
+#enable opengl support with nvidia gpu
+RUN printf '%s\n' \
+  '{' \
+  '    "file_format_version" : "1.0.0",' \
+  '    "ICD" : {' \
+  '        "library_path" : "libEGL_nvidia.so.0"' \
+  '    }' \
+  '}' > /usr/share/glvnd/egl_vendor.d/10_nvidia.json
 
 # Conda setup
 RUN mkdir -p /workspace/comfystream && \


### PR DESCRIPTION
Updates to comfystream dockerfile to enable mediapipe vision tasks to run on GPU.  

The file /usr/share/glvnd/egl_vendor.d/10_nvidia.json is available on host machine but was not seeing it in docker container.  Adding this file and installing `libglvnd-dev` in container enabled mediapipe to use tensorflow lite gpu delegates.

Logs from successfully loading task to GPU:

```
demo-comfystream  | Attempting to load MediaPipe model: Task='hand_landmarker', Variant='default'
demo-comfystream  | Successfully loaded model info: Path='/workspace/ComfyUI/models/mediapipe/hand_landmarker/hand_landmarker.task', Task='hand_landmarker', Variant='default'
demo-comfystream  | Creating new HandLandmarkDetector instance for /workspace/ComfyUI/models/mediapipe/hand_landmarker/hand_landmarker.task
demo-comfystream  | WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
demo-comfystream  | I0000 00:00:1747544968.308048    1737 gl_context_egl.cc:85] Successfully initialized EGL. Major : 1 Minor: 5
demo-comfystream  | I0000 00:00:1747544968.369380    1822 gl_context.cc:369] GL version: 3.2 (OpenGL ES 3.2 NVIDIA 570.144), renderer: NVIDIA GeForce RTX 5090/PCIe/SSE2
demo-comfystream  | INFO: Created TensorFlow Lite delegate for GPU.
demo-comfystream  | E0000 00:00:1747544968.442765    1822 tensor.cc:410] Tensors are designed for single writes. Multiple writes to a Tensor instance are not supported and may lead to undefined behavior due to lack of synchronization.
demo-comfystream  | W0000 00:00:1747544968.449196    1838 landmark_projection_calculator.cc:186] Using NORM_RECT without IMAGE_DIMENSIONS is only supported for the square ROI. Provide IMAGE_DIMENSIONS or use PROJECTION_MATRIX.
```