### PR TITLE
fix: ensure audio-only streams trigger onStreamReady

### DIFF
--- a/ui/src/components/webcam.tsx
+++ b/ui/src/components/webcam.tsx
@@ -336,6 +336,13 @@ export function Webcam({
   const hasVideo = stream && stream.getVideoTracks().length > 0;
   const hasAudio = stream && stream.getAudioTracks().length > 0;
 
+  // Ensure audio only stream is passed to parent component.
+  useEffect(() => {
+    if (stream && !hasVideo && hasAudio) {
+      onStreamReady(stream);
+    }
+  }, [stream, hasVideo, hasAudio, onStreamReady]);
+
   // Return audio-only placeholder if we have audio but no video
   if (!hasVideo && hasAudio) {
     return (


### PR DESCRIPTION
This pull request fixes a bug introduced in #38, where the audio-only functionality was inadvertently broken. The issue occurred because `handleCanvasStreamReady`—which triggers `onStreamReady`—is not called when the user provides only audio. This commit ensures that in audio-only scenarios, `onStreamReady` is called directly, allowing `localStream` to be set and offer negotiation to begin as expected.