### PR TITLE
refactor: switch to upstream ComfyUI-Depth-Anything-TensorRT

### DIFF
--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -11,8 +11,7 @@ nodes:
 
   comfyui-depthanything-tensorrt:
     name: "ComfyUI DepthAnything TensorRT"
-    url: "https://github.com/rickstaa/ComfyUI-Depth-Anything-Tensorrt"
-    branch: "feature/add-export-trt-args"
+    url: "https://github.com/yuvraj108c/ComfyUI-Depth-Anything-Tensorrt"
     type: "tensorrt"
 
   # Ryan's nodes


### PR DESCRIPTION
We previously used a fork of https://github.com/yuvraj108c/ComfyUI-Depth-Anything-Tensorrt because the original
script lacked support for parameters needed to create multiple TensorRT engines. Now that https://github.com/yuvraj108c/ComfyUI-Depth-Anything-Tensorrt/pull/14 has been merged upstream, this workaround is no longer necessary. We can safely return to the main repository.
