### PR TITLE
feat: build static engines for portrait and landscape resolution

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -55,12 +55,12 @@ if [ "$1" = "--build-engines" ]; then
   # Build Dynamic Engine for Dreamshaper
   python src/comfystream/scripts/build_trt.py \
                 --model /workspace/ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
-                --out-engine /workspace/ComfyUI/output/tensorrt/dynamic-dreamshaper8_SD15_\$dyn-b-1-4-2-h-448-704-512-w-448-704-512_00001_.engine \
-                --width 512 \
-                --height 512 \
-                --min-width 448 \
-                --min-height 448 \
-                --max-width 704 \
+                --out-engine /workspace/ComfyUI/output/tensorrt/dynamic-dreamshaper8_SD15_$dyn-b-1-4-2-h-512-640-704-w-320-384-448_00001_.engine \
+                --width 384 \
+                --height 640 \
+                --min-width 320 \
+                --min-height 512 \
+                --max-width 448 \
                 --max-height 704
 
   # Build Engine for Depth Anything V2

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -49,15 +49,21 @@ if [ "$1" = "--build-engines" ]; then
   cd /workspace/comfystream
   conda activate comfystream
 
-  # Build Static Engine for Dreamshaper
-  python src/comfystream/scripts/build_trt.py --model /workspace/ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors --out-engine /workspace/ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\$stat-b-1-h-512-w-512_00001_.engine
+  # Build Static Engine for Dreamshaper - Square (512x512)
+  python src/comfystream/scripts/build_trt.py --model /workspace/ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors --out-engine /workspace/ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\$stat-b-1-h-512-w-512_00001_.engine --width 512 --height 512
+
+  # Build Static Engine for Dreamshaper - Portrait (384x704)
+  python src/comfystream/scripts/build_trt.py --model /workspace/ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors --out-engine /workspace/ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\$stat-b-1-h-384-w-704_00001_.engine --width 384 --height 704
+
+  # Build Static Engine for Dreamshaper - Landscape (704x384)
+  python src/comfystream/scripts/build_trt.py --model /workspace/ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors --out-engine /workspace/ComfyUI/output/tensorrt/static-dreamshaper8_SD15_\$stat-b-1-h-704-w-384_00001_.engine --width 704 --height 384
 
   # Build Dynamic Engine for Dreamshaper
   python src/comfystream/scripts/build_trt.py \
                 --model /workspace/ComfyUI/models/unet/dreamshaper-8-dmd-1kstep.safetensors \
-                --out-engine /workspace/ComfyUI/output/tensorrt/dynamic-dreamshaper8_SD15_$dyn-b-1-4-2-h-512-640-704-w-320-384-448_00001_.engine \
+                --out-engine /workspace/ComfyUI/output/tensorrt/dynamic-dreamshaper8_SD15_\$dyn-b-1-4-2-h-512-704-w-320-384-448_00001_.engine \
                 --width 384 \
-                --height 640 \
+                --height 704 \
                 --min-width 320 \
                 --min-height 512 \
                 --max-width 448 \


### PR DESCRIPTION
This change updates entrypoint.sh to compile two additional static dreamshaper8 tensorrt engines for Portrait (384x704) and Landscape (704x384) resolutions