### PR TITLE
setup_nodes: add support for commit hash and git pull for branches

### DIFF
--- a/src/comfystream/scripts/README.md
+++ b/src/comfystream/scripts/README.md
@@ -14,13 +14,18 @@
 
 From the repository root:
 
+> The `--workspace` flag is optional and will default to `$COMFY_UI_WORKSPACE` or `~/comfyui`.
+
+### Install custom nodes
 ```bash
-# Install both nodes and models (default workspace: ~/comfyui)
 python src/comfystream/scripts/setup_nodes.py --workspace /path/to/comfyui
+```
+> The optional flag `--pull-branches` can be used to ensure the latest git changes are pulled for any custom nodes defined with a `branch` in nodes.yaml
+
+### Download models and compile tensorrt engines
+```bash
 python src/comfystream/scripts/setup_models.py --workspace /path/to/comfyui
 ```
-
-> The `--workspace` flag is optional and will default to `$COMFY_UI_WORKSPACE` or `~/comfyui`.
 
 ## Configuration Examples
 
@@ -32,9 +37,12 @@ nodes:
     name: "ComfyUI TensorRT"
     url: "https://github.com/yondonfu/ComfyUI_TensorRT"
     type: "tensorrt"
+    branch: "master"
     dependencies:
       - "tensorrt"
 ```
+
+> The `branch` property can be substituted with a SHA-256 commit hash for pinning custom node versions 
 
 ### Models (models.yaml)
 


### PR DESCRIPTION
This change updates setup_nodes.py to accept either a branch name or SHA commit hash for each node in nodes.yml. 

If a branch name is used and the `--pull-branches` flag is passed to setup_nodes then any existing custom_nodes defined in nodes.yaml have `git pull` ran inside of them during setup. 

This change helps ensure that each docker build contains the latest commits when a branch name is set and allows pinning of a specific commit for more stable release builds