### PR TITLE
add docker build arg for cachebusting setup_nodes.py

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -7,6 +7,10 @@ FROM "${BASE_IMAGE}"
 ARG CONDA_VERSION \
     PYTHON_VERSION
 
+# Accept a build-arg that lets CI force-invalidate setup_nodes.py
+ARG CACHEBUST=static
+
+
 ENV TensorRT_ROOT=/opt/TensorRT-10.9.0.34 \
     DEBIAN_FRONTEND=noninteractive \
     CONDA_VERSION="${CONDA_VERSION}" \
@@ -84,6 +88,10 @@ RUN conda run -n comfystream --no-capture-output --cwd /workspace/ComfyUI pip in
 RUN ln -s /workspace/comfystream /workspace/ComfyUI/custom_nodes/comfystream
 RUN conda run -n comfystream --no-capture-output --cwd /workspace/comfystream pip install -e . --root-user-action=ignore
 RUN conda run -n comfystream --no-capture-output --cwd /workspace/comfystream python install.py --workspace /workspace/ComfyUI
+
+
+# Force-invalidate setup_nodes.py if build arg is provided
+ENV CACHEBUST=${CACHEBUST}
 
 # Run setup_nodes
 RUN conda run -n comfystream --no-capture-output --cwd /workspace/comfystream python src/comfystream/scripts/setup_nodes.py --workspace /workspace/ComfyUI

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -7,10 +7,6 @@ FROM "${BASE_IMAGE}"
 ARG CONDA_VERSION \
     PYTHON_VERSION
 
-# Accept a build-arg that lets CI force-invalidate setup_nodes.py
-ARG CACHEBUST=static
-
-
 ENV TensorRT_ROOT=/opt/TensorRT-10.9.0.34 \
     DEBIAN_FRONTEND=noninteractive \
     CONDA_VERSION="${CONDA_VERSION}" \
@@ -89,8 +85,8 @@ RUN ln -s /workspace/comfystream /workspace/ComfyUI/custom_nodes/comfystream
 RUN conda run -n comfystream --no-capture-output --cwd /workspace/comfystream pip install -e . --root-user-action=ignore
 RUN conda run -n comfystream --no-capture-output --cwd /workspace/comfystream python install.py --workspace /workspace/ComfyUI
 
-
-# Force-invalidate setup_nodes.py if build arg is provided
+# Accept a build-arg that lets CI force-invalidate setup_nodes.py
+ARG CACHEBUST=static
 ENV CACHEBUST=${CACHEBUST}
 
 # Run setup_nodes


### PR DESCRIPTION
from comments on: https://github.com/livepeer/comfystream/pull/217

We will need to use a cache-busting mechanism - something like a build arg in the dockerfile :
```
# Accept a build-arg that lets CI force-invalidate this layer.
ARG CACHEBUST=static
ENV CACHEBUST=${CACHEBUST}
```

That forces Docker to rerun the script and pull the latest main for nodes with main and the pinned version for those with SHAs. Checking for the presence of the node folders wont speed up in CI or docker builds, but may still be useful for running in a devcontainer.