### PR TITLE
add cachebust arg to base image CI build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -76,6 +76,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/Dockerfile.base
+          build-args: |
+            CACHEBUST=${{ github.run_id }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=registry,ref=livepeer/comfyui-base:build-cache


### PR DESCRIPTION
Follow-up to https://github.com/livepeer/comfystream/pull/218

Passes build arg in ci workflow for base image