### PR TITLE
feat: benchmark script

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,172 @@
+import av
+import json
+import time
+import torch
+import logging
+import asyncio
+import argparse
+import numpy as np
+
+from comfystream.client import ComfyStreamClient
+
+logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger()
+
+
+def create_dummy_video_frame(width, height):
+    frame = av.VideoFrame()
+    dummy_tensor = torch.randn(1, height, width, 3)
+    frame.side_data.input = dummy_tensor
+    return frame
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Benchmark ComfyStreamClient workflow execution.")
+    parser.add_argument("--workflow-path", default="./workflows/comfystream/tensor-utils-example-api.json", help="Path to the workflow JSON file.")
+    parser.add_argument("--num-requests", type=int, default=100, help="Number of requests to send.")
+    parser.add_argument("--fps", type=float, default=None, help="Frames per second for FPS-based benchmarking.")
+    parser.add_argument("--cwd", default="/workspace/ComfyUI", help="Current working directory for ComfyStreamClient.")
+    parser.add_argument("--width", type=int, default=512, help="Width of dummy video frames.")
+    parser.add_argument("--height", type=int, default=512, help="Height of dummy video frames.")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging (shows progress for each request).")
+    parser.add_argument("--warmup-runs", type=int, default=5, help="Number of warm-up runs before benchmarking.")
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
+    with open(args.workflow_path, "r") as f:
+        prompt = json.load(f)
+
+    client = ComfyStreamClient(cwd=args.cwd)
+    await client.set_prompts([prompt])
+
+    logger.info(f"Starting benchmark with workflow: {args.workflow_path}, requests: {args.num_requests}, resolution: {args.width}x{args.height}, warmup runs: {args.warmup_runs}")
+
+    if args.warmup_runs > 0:
+        logger.info(f"Running {args.warmup_runs} warm-up runs...")
+        for _ in range(args.warmup_runs):
+            frame = create_dummy_video_frame(args.width, args.height)
+            client.put_video_input(frame)
+            await client.get_video_output()
+        logger.info("Warm-up complete.")
+
+    if args.fps is None:
+        logger.info("Running sequential benchmark...")
+        start_time = time.time()
+        round_trip_times = []
+
+        for i in range(args.num_requests):
+            frame = create_dummy_video_frame(args.width, args.height)
+            request_start_time = time.time()
+            client.put_video_input(frame)
+            await client.get_video_output()
+            request_end_time = time.time()
+            round_trip_times.append(request_end_time - request_start_time)
+            logger.debug(f"Request {i+1}/{args.num_requests} completed in {round_trip_times[-1]:.4f} seconds")
+
+        end_time = time.time()
+        total_time = end_time - start_time
+        output_fps = args.num_requests / total_time if total_time > 0 else float('inf')
+
+        # Calculate percentiles for sequential mode
+        p50_rtt = np.percentile(round_trip_times, 50)
+        p75_rtt = np.percentile(round_trip_times, 75)
+        p90_rtt = np.percentile(round_trip_times, 90)
+        p95_rtt = np.percentile(round_trip_times, 95)
+        p99_rtt = np.percentile(round_trip_times, 99)
+
+        print("\n" + "="*40)
+        print("FPS Results:")
+        print("="*40)
+        print(f"Total requests: {args.num_requests}")
+        print(f"Total time:     {total_time:.4f} seconds")
+        print(f"Actual Output FPS:{output_fps:.2f}")
+        print(f"Total requests:   {args.num_requests}")
+        print(f"Total time:       {total_time:.4f} seconds")
+        print("\n" + "="*40)
+        print("Latency Results:")
+        print("="*40)
+        print(f"Average: {np.mean(round_trip_times):.4f}")
+        print(f"Min:     {np.min(round_trip_times):.4f}")
+        print(f"Max:     {np.max(round_trip_times):.4f}")
+        print(f"P50:     {p50_rtt:.4f}")
+        print(f"P75:     {p75_rtt:.4f}")
+        print(f"P90:     {p90_rtt:.4f}")
+        print(f"P95:     {p95_rtt:.4f}")
+        print(f"P99:     {p99_rtt:.4f}")
+
+
+    else:
+        logger.info(f"Running FPS-based benchmark at {args.fps} FPS...")
+        frame_interval = 1.0 / args.fps
+        start_time = time.time()
+        latencies = []
+        output_tasks = []
+        sent_times = []
+
+        for i in range(args.num_requests):
+            frame = create_dummy_video_frame(args.width, args.height)
+
+            elapsed = time.time() - start_time
+            expected_elapsed = i * frame_interval
+            sleep_time = expected_elapsed - elapsed
+            if sleep_time > 0:
+                await asyncio.sleep(sleep_time)
+
+            request_send_time = time.time()
+            client.put_video_input(frame)
+            sent_times.append(request_send_time)
+
+            output_tasks.append(asyncio.create_task(client.get_video_output()))
+
+            logger.debug(f"Sent request {i+1}/{args.num_requests} at {request_send_time - start_time:.4f} seconds")
+
+        all_outputs_received_time = time.time()
+        for i, task in enumerate(output_tasks):
+            output_receive_time = time.time()
+            await task
+            latency = output_receive_time - sent_times[i]
+            latencies.append(latency)
+            logger.debug(f"Received output for request {i+1}/{args.num_requests} at {output_receive_time - start_time:.4f} seconds, Latency: {latency:.4f} seconds")
+
+        end_time = time.time()
+        total_time = end_time - start_time
+        output_collection_duration = all_outputs_received_time - start_time
+        output_fps = args.num_requests / output_collection_duration if output_collection_duration > 0 else float('inf')
+
+        # The workflow is async, so the latency numbers might not make sense in this context.
+        # We're just using them to get a sense of the distribution of latencies.
+        p50_latency = np.percentile(latencies, 50)
+        p75_latency = np.percentile(latencies, 75)
+        p90_latency = np.percentile(latencies, 90)
+        p95_latency = np.percentile(latencies, 95)
+        p99_latency = np.percentile(latencies, 99)
+
+        print("\n" + "="*40)
+        print("FPS Results:")
+        print("="*40)
+        print(f"Target Input FPS: {args.fps:.2f}")
+        print(f"Actual Output FPS:{output_fps:.2f}")
+        print(f"Total requests:   {args.num_requests}")
+        print(f"Total time:       {total_time:.4f} seconds")
+        print("\n" + "="*40)
+        print("Latency Results:")
+        print("="*40)
+        print(f"Average: {np.mean(latencies):.4f}")
+        print(f"Min:     {np.min(latencies):.4f}")
+        print(f"Max:     {np.max(latencies):.4f}")
+        print(f"P50:     {p50_latency:.4f}")
+        print(f"P75:     {p75_latency:.4f}")
+        print(f"P90:     {p90_latency:.4f}")
+        print(f"P95:     {p95_latency:.4f}")
+        print(f"P99:     {p99_latency:.4f}")
+
+    await client.cleanup()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
- The PR adds support of a benchmark script, which would help us determine the accurate FPS possible on the machine instead of spinning up a E2E comfystream
- This is needed to compare machines without the network latencies coming into the picture
- The next step is to integrate this into the ComfyUI comfystream panel to directly spin up a benchmark without running it manually with a command in the terminal