### PR TITLE
fix: set_prompts cleanup

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -256,7 +256,10 @@ async def offer(request):
                                 "[Control] Missing prompt in update_prompt message"
                             )
                             return
-                        await pipeline.update_prompts(params["prompts"])
+                        try:
+                            await pipeline.update_prompts(params["prompts"])
+                        except Exception as e:
+                            print("Error updating the prompt", e)
                         response = {"type": "prompts_updated", "success": True}
                         channel.send(json.dumps(response))
                     elif params.get("type") == "update_resolution":

--- a/server/app.py
+++ b/server/app.py
@@ -259,7 +259,7 @@ async def offer(request):
                         try:
                             await pipeline.update_prompts(params["prompts"])
                         except Exception as e:
-                            print("Error updating the prompt", e)
+                            logger.error(f"Error updating prompt: {str(e)}")
                         response = {"type": "prompts_updated", "success": True}
                         channel.send(json.dumps(response))
                     elif params.get("type") == "update_resolution":

--- a/src/comfystream/client.py
+++ b/src/comfystream/client.py
@@ -21,7 +21,7 @@ class ComfyStreamClient:
         self.cleanup_lock = asyncio.Lock()
 
     async def set_prompts(self, prompts: List[PromptDictInput]):
-        await self.cancel_running_tasks()
+        await self.cancel_running_prompts()
         self.current_prompts = [convert_prompt(prompt) for prompt in prompts]
         for idx in range(len(self.current_prompts)):
             task = asyncio.create_task(self.run_prompt(idx))
@@ -54,7 +54,7 @@ class ComfyStreamClient:
                 raise
 
     async def cleanup(self):
-        await self.cancel_running_tasks()
+        await self.cancel_running_prompts()
         async with self.cleanup_lock:
             if self.comfy_client.is_running:
                 try:
@@ -65,7 +65,7 @@ class ComfyStreamClient:
             await self.cleanup_queues()
             logger.info("Client cleanup complete")
 
-    async def cancel_running_tasks(self):
+    async def cancel_running_prompts(self):
         async with self.cleanup_lock:
             tasks_to_cancel = list(self.running_prompts.values())
             for task in tasks_to_cancel:


### PR DESCRIPTION
if the update_prompts fails, then the running prompt task closes and new running task needs to be started, so added a safety net of cleanup before the set_prompts 