### PR TITLE
bump ver to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfystream"
 description = "Build Live AI Video with ComfyUI"
-version = "0.1.0"
+version = "0.1.1"
 license = { file = "LICENSE" }
 dependencies = [
     "asyncio",

--- a/scripts/ansible/plays/setup_comfystream.yaml
+++ b/scripts/ansible/plays/setup_comfystream.yaml
@@ -3,7 +3,7 @@
   hosts: all
   become: yes
   vars:
-    docker_image: "livepeer/comfystream:v0.1.0"
+    docker_image: "livepeer/comfystream:stable"
     comfyui_username: "comfyadmin"
   tasks:
     ###################################################################

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-dialog": "^1.1.6",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "cross-env NEXT_PUBLIC_DEV=true next dev",


### PR DESCRIPTION
This change bumps the comfystream version to 0.1.1 from 0.1.0 due to an issue publishing to the ComfyUI Registry. This change also updates docker image tag in the ansible script to use the stable tag which is updated to match each release.

**Note**: v0.1.1 was published to the registry from https://github.com/yondonfu/comfystream/releases/tag/v0.1.1 using https://github.com/yondonfu/comfystream/compare/release/v0.1.1 since 0.1.0 was not published yet.

Tested deployment to registry successfully with the following on linux env:
```
conda create --name comfystream python=3.11
conda activate comfystream
pip install comfy-cli
comfy install --version 0.3.27
comfy node registry-install comfystream
comfy launch
```
This PR is to cherry-pick the same commit so that 0.1.2 can be tagged at a later date