### PR TITLE
fix: devcontainer git permissions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,8 @@
 	"mounts": [
 		// Use 'mounts' to map to comfyui models on the host
 		"source=${localEnv:HOME}/models/ComfyUI--models,target=/workspace/ComfyUI/models,type=bind,consistency=cached",
-		"source=${localEnv:HOME}/models/ComfyUI--output,target=/workspace/ComfyUI/output,type=bind,consistency=cached"
+		"source=${localEnv:HOME}/models/ComfyUI--output,target=/workspace/ComfyUI/output,type=bind,consistency=cached",
+		"type=bind,source=/home/${localEnv:USER}/.ssh,target=/root/.ssh,readonly"
 	],
 	"postCreateCommand": ".devcontainer/post-create.sh"
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -26,4 +26,10 @@ echo 'alias prepare_examples="/workspace/comfystream/docker/entrypoint.sh --down
 echo -e "\e[32mContainer ready! Run 'prepare_examples' to download models and build engines for example workflows.\e[0m"
 
 cd /workspace/comfystream
-/bin/bash
+
+# Ensure git doesn't complain about comfystream directory ownership
+git config --global --add safe.directory /workspace/comfystream
+
+# Print final success message
+echo -e "\e[32mDevelopment environment setup complete!\e[0m"
+


### PR DESCRIPTION
This change resolves two issues when developing in a devcontainer

1. Clears **Manage unsafe repositories** message - ensures the devcontainer can access the host git repo by adding `git config --global --add safe.directory /workspace/comfystream` to via `post-create.sh`

2. Mounts ssh keys from host `/home/${localEnv:USER}/.ssh` in devcontainer at `/root/.ssh` to allow commit and push from devcontainer