### PR TITLE
chore: bump version to 0.1.2 in pyproject.toml and package.json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfystream"
 description = "Build Live AI Video with ComfyUI"
-version = "0.1.1"
+version = "0.1.2"
 license = { file = "LICENSE" }
 dependencies = [
     "asyncio",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "cross-env NEXT_PUBLIC_DEV=true next dev",


### PR DESCRIPTION
This PR bumps the version of comfystream from v0.1.1 to v0.1.2

The version upgrade includes feature for obs streaming url https://github.com/livepeer/comfystream/pull/85