### PR TITLE
Revert "fix: version bug resolve for ComfyUI blocked at 0.3.27 "

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -64,7 +64,7 @@ RUN conda run -n comfystream pip install --no-cache-dir \
     ${TensorRT_ROOT}/python/tensorrt-10.9.0.34-cp311-none-linux_x86_64.whl
 
 # Clone ComfyUI
-RUN git clone --branch v0.3.39 --depth 1 https://github.com/comfyanonymous/ComfyUI.git /workspace/ComfyUI
+RUN git clone --branch v0.3.27 --depth 1 https://github.com/comfyanonymous/ComfyUI.git /workspace/ComfyUI
 
 # Copy only files needed for setup
 COPY ./src/comfystream/scripts /workspace/comfystream/src/comfystream/scripts
@@ -104,8 +104,5 @@ RUN conda config --set auto_activate_base false && \
 
 # Set comfystream environment as default
 RUN echo "conda activate comfystream" >> ~/.bashrc
-
-# Set /workspace/ComfyUI to PYTHONPATH
-RUN echo "export PYTHONPATH=/workspace/ComfyUI" >> ~/.bashrc
 
 WORKDIR /workspace/comfystream

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.1.2"
 license = { file = "LICENSE" }
 dependencies = [
     "asyncio",
-    "comfyui @ git+https://github.com/livepeer/ComfyUI.git@6a39b5b016cc108cbc5dda2fd4b32a51161ab150",
+    "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@ce3583ad42c024b8f060d0002cbe20c265da6dc8",
     "aiortc",
     "aiohttp",
     "aiohttp_cors",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asyncio
-comfyui @ git+https://github.com/livepeer/ComfyUI.git@6a39b5b016cc108cbc5dda2fd4b32a51161ab150
+comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@ce3583ad42c024b8f060d0002cbe20c265da6dc8
 aiortc
 aiohttp
 aiohttp_cors

--- a/src/comfystream/client.py
+++ b/src/comfystream/client.py
@@ -5,9 +5,9 @@ import logging
 from comfystream import tensor_cache
 from comfystream.utils import convert_prompt
 
-from hiddenswitch_comfy.api.components.schema.prompt import PromptDictInput
-from hiddenswitch_comfy.cli_args_types import Configuration
-from hiddenswitch_comfy.client.embedded_comfy_client import EmbeddedComfyClient
+from comfy.api.components.schema.prompt import PromptDictInput
+from comfy.cli_args_types import Configuration
+from comfy.client.embedded_comfy_client import EmbeddedComfyClient
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +114,7 @@ class ComfyStreamClient:
             return {}
 
         try:
-            from hiddenswitch_comfy.nodes.package import import_all_nodes_in_workspace
+            from comfy.nodes.package import import_all_nodes_in_workspace
             nodes = import_all_nodes_in_workspace()
 
             all_prompts_nodes_info = {}

--- a/src/comfystream/utils.py
+++ b/src/comfystream/utils.py
@@ -1,7 +1,7 @@
 import copy
 
 from typing import Dict, Any
-from hiddenswitch_comfy.api.components.schema.prompt import Prompt, PromptDictInput
+from comfy.api.components.schema.prompt import Prompt, PromptDictInput
 
 
 def create_load_tensor_node():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from hiddenswitch_comfy.api.components.schema.prompt import Prompt
+from comfy.api.components.schema.prompt import Prompt
 from comfystream.utils import convert_prompt
 
 


### PR DESCRIPTION
Reverting change due to need for pythonpath affecting ai-runner `Error in process run method: No module named 'comfy'`

This is due to how infer.py is run as a subprocess, lacking the PYTHONPATH variable. Attempted to set it in ai-runner a few different ways with no success

Logs
```
timestamp=2025-06-09 20:32:42 level=ERROR location=process.py:350:_report_error gateway_request_id= manifest_id= stream_id= message=Error loading pipeline: No module named 'comfy'
timestamp=2025-06-09 20:32:42 level=ERROR location=process.py:350:_report_error gateway_request_id= manifest_id= stream_id= message=Error in process run method: No module named 'comfy'
```