### PR TITLE
feat: Load hiddenswitch comfyui using importlib in comfystream server process

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,36 +1,31 @@
 import os
 import pathlib
+success = True
 
-def ensure_init_files():
-    """Create __init__.py files in comfy/ and comfy_extras/ directories if they don't exist"""
-    # Go up two levels from custom_nodes/comfystream_inside to reach ComfyUI root
-    comfy_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-    base_dirs = ['comfy', 'comfy_extras']
-    for base_dir in base_dirs:
-        base_path = os.path.join(comfy_root, base_dir)
-        if not os.path.exists(base_path):
-            continue
-            
-        # Create __init__.py in the root of base_dir first
-        root_init = os.path.join(base_path, "__init__.py")
-        if not os.path.exists(root_init):
-            with open(root_init, 'w') as f:
-                f.write("")
-                
-        # Then walk subdirectories
-        for root, dirs, files in os.walk(base_path):
-            init_path = os.path.join(root, "__init__.py")
-            if not os.path.exists(init_path):
-                with open(init_path, 'w') as f:
-                    f.write("")
+import sys
+from pathlib import Path
+root = Path(__file__).resolve().parent
 
-# Create __init__.py files in ComfyUI directories
-ensure_init_files()
-
+sys.path.insert(0, str(root / 'src'))
+import nodes
+from nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 # Point to the directory containing our web files
 WEB_DIRECTORY = "./nodes/web/js"
 
 # Import and expose node classes
 from .nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
-__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS'] 
+from comfystream.tensor_cache import (
+    image_inputs,
+    image_outputs, 
+    audio_inputs,
+    audio_outputs
+)
+
+# Or import the entire module
+from . import tensor_cache
+
+__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS', 
+           'image_inputs', 'image_outputs', 
+           'audio_inputs', 'audio_outputs',
+           'tensor_cache']

--- a/debug_imports.py
+++ b/debug_imports.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Simple debug script to test ComfyUI imports
+"""
+
+import sys
+from pathlib import Path
+
+# Add the src directory to the path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+import logging
+
+# Setup logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+def test_path_setup():
+    """Test the basic path setup"""
+    print("=== Testing Path Setup ===")
+    
+    # Check if external directory exists
+    external_path = Path(__file__).parent / "external"
+    print(f"External path: {external_path}")
+    print(f"External path exists: {external_path.exists()}")
+    
+    # Check if comfy directory exists
+    comfy_path = external_path / "comfy"
+    print(f"Comfy path: {comfy_path}")
+    print(f"Comfy path exists: {comfy_path.exists()}")
+    
+    # Check if __init__.py exists
+    init_path = comfy_path / "__init__.py"
+    print(f"Init file: {init_path}")
+    print(f"Init file exists: {init_path.exists()}")
+    
+    return external_path, comfy_path
+
+def test_manual_import():
+    """Test manual import of comfy"""
+    print("\n=== Testing Manual Import ===")
+    
+    external_path, comfy_path = test_path_setup()
+    
+    if not external_path.exists():
+        print("❌ External path doesn't exist")
+        return False
+    
+    # Add external path to sys.path
+    external_str = str(external_path)
+    if external_str not in sys.path:
+        sys.path.insert(0, external_str)
+        print(f"✓ Added {external_str} to sys.path")
+    
+    print(f"Current sys.path (first 3): {sys.path[:3]}")
+    
+    # Try to import comfy directly
+    try:
+        import comfy
+        print(f"✓ Successfully imported comfy: {comfy}")
+        print(f"✓ Comfy version: {getattr(comfy, '__version__', 'unknown')}")
+        print(f"✓ Comfy file: {getattr(comfy, '__file__', 'unknown')}")
+        return True
+    except ImportError as e:
+        print(f"❌ Failed to import comfy: {e}")
+        return False
+
+def test_loader():
+    """Test the comfy loader"""
+    print("\n=== Testing ComfyUI Loader ===")
+    
+    try:
+        from comfystream.comfy_loader import ComfyModuleLoader
+        
+        # Create a loader
+        loader = ComfyModuleLoader()
+        print(f"✓ Created loader with path: {loader.comfyui_path}")
+        
+        # Test path setup
+        loader.setup_python_path()
+        print("✓ Path setup completed")
+        
+        # Test loading comfy module
+        comfy = loader.load_comfy_module("comfy")
+        print(f"✓ Loaded comfy module: {comfy}")
+        
+        return True
+        
+    except Exception as e:
+        print(f"❌ Loader test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def main():
+    """Run all tests"""
+    print("ComfyUI Import Debug Script")
+    print("=" * 40)
+    
+    # Test manual import first
+    manual_success = test_manual_import()
+    
+    if manual_success:
+        # If manual import works, test the loader
+        loader_success = test_loader()
+        
+        if loader_success:
+            print("\n🎉 All tests passed!")
+        else:
+            print("\n⚠ Loader test failed, but manual import worked")
+    else:
+        print("\n❌ Manual import failed - check path configuration")
+    
+    print(f"\nFinal sys.path (first 5): {sys.path[:5]}")
+
+if __name__ == "__main__":
+    main()

--- a/demo_usage.py
+++ b/demo_usage.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+Demonstration of ComfyStream utils and client usage
+"""
+
+import sys
+import asyncio
+from pathlib import Path
+
+# Add the src directory to the path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+import logging
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+async def demo_basic_usage():
+    """Demonstrate basic usage of ComfyStream components"""
+    print("=== ComfyStream Basic Usage Demo ===")
+    
+    # 1. Import and use utils
+    print("\n1. Using ComfyStream Utils:")
+    from comfystream.utils import (
+        create_load_tensor_node,
+        create_save_tensor_node,
+        convert_prompt,
+        Prompt
+    )
+    
+    # Create tensor nodes
+    load_node = create_load_tensor_node()
+    save_node = create_save_tensor_node({"format": "png"})
+    
+    print(f"   Load node: {load_node}")
+    print(f"   Save node: {save_node}")
+    
+    # 2. Work with prompts
+    print("\n2. Working with Prompts:")
+    
+    # Create a sample prompt
+    sample_prompt = {
+        "1": {
+            "class_type": "PrimaryInputLoadImage",
+            "inputs": {}
+        },
+        "2": {
+            "class_type": "SomeProcessingNode",
+            "inputs": {
+                "image": ["1", 0],
+                "strength": 0.8
+            }
+        },
+        "3": {
+            "class_type": "PreviewImage",
+            "inputs": {
+                "images": ["2", 0]
+            }
+        }
+    }
+    
+    print(f"   Original prompt: {sample_prompt}")
+    
+    # Validate and convert the prompt
+    try:
+        validated = Prompt.validate(sample_prompt)
+        print("   ✓ Prompt validation successful")
+        
+        converted = convert_prompt(sample_prompt)
+        print(f"   ✓ Converted prompt: {converted}")
+        
+    except Exception as e:
+        print(f"   ⚠ Prompt processing: {e}")
+
+async def demo_client_usage():
+    """Demonstrate client usage"""
+    print("\n=== ComfyStream Client Demo ===")
+    
+    try:
+        from comfystream.client import ComfyStreamClient
+        
+        print("\n1. Creating ComfyStream Client:")
+        
+        # Create client with configuration
+        client = ComfyStreamClient(max_workers=2)
+        print("   ✓ Client created successfully")
+        
+        print("\n2. Client Methods Available:")
+        methods = [attr for attr in dir(client) if not attr.startswith('_') and callable(getattr(client, attr))]
+        for method in methods[:10]:  # Show first 10 methods
+            print(f"   - {method}")
+        if len(methods) > 10:
+            print(f"   ... and {len(methods) - 10} more methods")
+        
+        print("\n3. Client Configuration:")
+        if hasattr(client, 'comfy_client'):
+            print("   ✓ ComfyUI client initialized")
+        else:
+            print("   ⚠ ComfyUI client not initialized")
+        
+        # Cleanup
+        await client.cleanup()
+        print("   ✓ Client cleanup completed")
+        
+    except Exception as e:
+        print(f"   ⚠ Client demo failed: {e}")
+
+async def demo_advanced_usage():
+    """Demonstrate advanced usage patterns"""
+    print("\n=== Advanced Usage Patterns ===")
+    
+    # 1. Custom loader usage
+    print("\n1. Custom ComfyUI Loader:")
+    from comfystream.comfy_loader import ComfyModuleLoader, discover_available_modules
+    
+    # Discover available modules
+    modules = discover_available_modules()
+    print(f"   Found {len(modules)} available ComfyUI modules")
+    
+    # Show some example modules
+    example_modules = [m for m in modules if any(keyword in m for keyword in ['api', 'model', 'sample'])][:5]
+    print(f"   Example modules: {example_modules}")
+    
+    # 2. Pattern-based loading
+    print("\n2. Pattern-based Module Loading:")
+    from comfystream.comfy_loader import load_modules_matching
+    
+    try:
+        api_modules = load_modules_matching("api")
+        print(f"   Loaded {len(api_modules)} API-related modules")
+        
+        model_modules = load_modules_matching("model")
+        print(f"   Loaded {len(model_modules)} model-related modules")
+        
+    except Exception as e:
+        print(f"   ⚠ Pattern loading: {e}")
+    
+    # 3. Error handling patterns
+    print("\n3. Error Handling Patterns:")
+    from comfystream.utils import convert_prompt
+    
+    # Test with invalid prompt
+    invalid_prompt = {
+        "1": {"class_type": "InvalidNode", "inputs": {}},
+        "2": {"class_type": "AnotherInvalidNode", "inputs": {}}
+    }
+    
+    try:
+        convert_prompt(invalid_prompt)
+        print("   ⚠ Expected error but conversion succeeded")
+    except Exception as e:
+        print(f"   ✓ Properly caught error: {str(e)[:60]}...")
+
+async def demo_integration_patterns():
+    """Demonstrate integration patterns for applications"""
+    print("\n=== Integration Patterns ===")
+    
+    # Example application class
+    class ComfyStreamApp:
+        def __init__(self):
+            self.client = None
+            self.loaded_modules = {}
+        
+        async def initialize(self):
+            """Initialize the application"""
+            try:
+                from comfystream.client import ComfyStreamClient
+                from comfystream.comfy_loader import get_essential_comfy
+                
+                # Load essential ComfyUI components
+                self.comfy = get_essential_comfy()
+                print("   ✓ ComfyUI components loaded")
+                
+                # Create client
+                self.client = ComfyStreamClient(max_workers=1)
+                print("   ✓ ComfyStream client created")
+                
+                return True
+                
+            except Exception as e:
+                print(f"   ✗ Initialization failed: {e}")
+                return False
+        
+        async def process_prompt(self, prompt_data):
+            """Process a prompt through the pipeline"""
+            try:
+                from comfystream.utils import convert_prompt
+                
+                # Convert the prompt
+                converted = convert_prompt(prompt_data)
+                print(f"   ✓ Prompt converted: {len(converted)} nodes")
+                
+                # Here you would queue it with the client
+                # await self.client.set_prompts([converted])
+                
+                return converted
+                
+            except Exception as e:
+                print(f"   ✗ Prompt processing failed: {e}")
+                return None
+        
+        async def cleanup(self):
+            """Cleanup resources"""
+            if self.client:
+                await self.client.cleanup()
+                print("   ✓ Application cleanup completed")
+    
+    # Demonstrate the application
+    print("\n1. Application Integration:")
+    app = ComfyStreamApp()
+    
+    if await app.initialize():
+        # Test with a sample prompt
+        sample_prompt = {
+            "1": {"class_type": "PrimaryInputLoadImage", "inputs": {}},
+            "2": {"class_type": "PreviewImage", "inputs": {"images": ["1", 0]}}
+        }
+        
+        result = await app.process_prompt(sample_prompt)
+        if result:
+            print("   ✓ Prompt processing successful")
+        
+        await app.cleanup()
+
+async def main():
+    """Run the demonstration"""
+    print("ComfyStream Utils and Client Demonstration")
+    print("=" * 60)
+    
+    # Run all demos
+    demos = [
+        demo_basic_usage,
+        demo_client_usage,
+        demo_advanced_usage,
+        demo_integration_patterns
+    ]
+    
+    for demo in demos:
+        try:
+            await demo()
+        except Exception as e:
+            print(f"Demo failed: {e}")
+            import traceback
+            traceback.print_exc()
+    
+    print("\n" + "=" * 60)
+    print("🎉 Demonstration completed!")
+    print("\nKey takeaways:")
+    print("- ComfyUI modules are loaded dynamically using the enhanced loader")
+    print("- Utils provide prompt conversion and tensor node creation")
+    print("- Client provides async interface for ComfyUI operations")
+    print("- Error handling is built into all components")
+    print("- Integration patterns support real applications")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -64,7 +64,12 @@ RUN conda run -n comfystream pip install --no-cache-dir \
     ${TensorRT_ROOT}/python/tensorrt-10.9.0.34-cp311-none-linux_x86_64.whl
 
 # Clone ComfyUI
-RUN git clone --branch v0.3.27 --depth 1 https://github.com/comfyanonymous/ComfyUI.git /workspace/ComfyUI
+RUN git clone --branch v0.3.29 --depth 1 https://github.com/comfyanonymous/ComfyUI.git /workspace/ComfyUI
+RUN git clone --single-branch --branch master --depth 1 https://github.com/hiddenswitch/ComfyUI.git /workspace/comfystream/external
+# TODO (Faster) - Write into comfyui loader
+# RUN wget http://github.com/comfyanonymous/ComfyUI/archive/564e14ea973b58a87e97eff40655ec3617946d19.zip -O /workspace/ComfyUI.zip && \
+#     unzip /workspace/ComfyUI.zip -d /workspace/external
+
 
 # Copy only files needed for setup
 COPY ./src/comfystream/scripts /workspace/comfystream/src/comfystream/scripts

--- a/example_usage.py
+++ b/example_usage.py
@@ -1,0 +1,188 @@
+"""
+Example usage of the enhanced ComfyUI module loader
+"""
+
+# Import the loader functions
+from comfystream.comfy_loader import (
+    get_comfy_namespace,
+    get_essential_comfy,
+    discover_available_modules,
+    load_specific_module,
+    load_modules_matching,
+    default_loader,
+    ComfyModuleLoader
+)
+
+# Example 1: Quick start - Load essential modules only
+def quick_start_example():
+    """Load just the essential modules for basic functionality"""
+    comfy = get_essential_comfy()
+    
+    # Now you can use comfy.utils, comfy.model_management, etc.
+    # These modules are automatically loaded and available
+    return comfy
+
+# Example 2: Full namespace - Load everything available
+def full_namespace_example():
+    """Load the complete comfy namespace with all discovered modules"""
+    comfy = get_comfy_namespace()
+    
+    # This loads the main comfy module plus all core modules
+    # Additional modules can be loaded on-demand
+    return comfy
+
+# Example 3: Discover what's available
+def discovery_example():
+    """Discover all available modules before loading"""
+    # Get list of all available modules
+    available_modules = discover_available_modules()
+    print(f"Available modules: {len(available_modules)}")
+    
+    # Filter for specific types
+    api_modules = [m for m in available_modules if 'api' in m]
+    model_modules = [m for m in available_modules if 'model' in m]
+    
+    print(f"API-related modules: {api_modules}")
+    print(f"Model-related modules: {model_modules}")
+    
+    return available_modules
+
+# Example 4: Load specific modules on demand
+def on_demand_loading_example():
+    """Load specific modules only when needed"""
+    # Load just the modules you need
+    utils_module = load_specific_module("comfy.utils")
+    model_mgmt = load_specific_module("comfy.model_management")
+    
+    # Use the modules
+    # utils_module.some_function()
+    # model_mgmt.some_other_function()
+    
+    return utils_module, model_mgmt
+
+# Example 5: Pattern-based loading
+def pattern_loading_example():
+    """Load modules matching specific patterns"""
+    # Load all API-related modules
+    api_modules = load_modules_matching("api")
+    
+    # Load all sampling-related modules
+    sampling_modules = load_modules_matching("sample")
+    
+    # Load all model-related modules
+    model_modules = load_modules_matching("model")
+    
+    return api_modules, sampling_modules, model_modules
+
+# Example 6: Custom loader with different path
+def custom_loader_example():
+    """Create a custom loader with different settings"""
+    # Create a custom loader for a different ComfyUI installation
+    custom_loader = ComfyModuleLoader(
+        comfyui_path="/custom/path/to/comfyui"
+    )
+    
+    # Use the custom loader
+    modules = custom_loader.discover_comfy_modules()
+    comfy = custom_loader.load_complete_namespace()
+    
+    return custom_loader, comfy
+
+# Example 7: Error handling and debugging
+def robust_loading_example():
+    """Demonstrate robust loading with error handling"""
+    try:
+        # Attempt to load complete namespace
+        comfy = get_comfy_namespace()
+        
+        # Check what modules were actually loaded
+        loaded_modules = default_loader.get_loaded_modules()
+        print(f"Successfully loaded {len(loaded_modules)} modules")
+        
+        # Try to access specific functionality
+        if 'comfy.utils' in loaded_modules:
+            utils = loaded_modules['comfy.utils']
+            print("Utils module available")
+        
+        return comfy
+        
+    except ImportError as e:
+        print(f"Import error: {e}")
+        # Fallback to essential modules only
+        return get_essential_comfy()
+    
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+        return None
+
+# Example 8: Integration in your application
+class MyComfyApplication:
+    """Example application using the ComfyUI loader"""
+    
+    def __init__(self):
+        self.comfy_loader = default_loader
+        self.comfy = None
+        self.loaded_modules = {}
+    
+    def initialize(self):
+        """Initialize the ComfyUI modules"""
+        try:
+            # Discover available modules
+            available = self.comfy_loader.discover_comfy_modules()
+            print(f"Found {len(available)} available ComfyUI modules")
+            
+            # Load essential modules
+            self.comfy = get_essential_comfy()
+            
+            # Load additional modules as needed
+            self._load_additional_modules()
+            
+            print("ComfyUI initialization complete")
+            return True
+            
+        except Exception as e:
+            print(f"Failed to initialize ComfyUI: {e}")
+            return False
+    
+    def _load_additional_modules(self):
+        """Load additional modules based on application needs"""
+        additional_modules = [
+            "comfy.api",
+            "comfy.graph",
+            "comfy.nodes"
+        ]
+        
+        for module_name in additional_modules:
+            try:
+                module = load_specific_module(module_name)
+                self.loaded_modules[module_name] = module
+                print(f"Loaded additional module: {module_name}")
+            except ImportError:
+                print(f"Optional module not available: {module_name}")
+    
+    def get_module(self, module_name: str):
+        """Get a specific loaded module"""
+        if module_name in self.loaded_modules:
+            return self.loaded_modules[module_name]
+        
+        # Try to load it on demand
+        try:
+            module = load_specific_module(module_name)
+            self.loaded_modules[module_name] = module
+            return module
+        except ImportError:
+            return None
+
+if __name__ == "__main__":
+    # Run examples
+    print("=== ComfyUI Loader Examples ===")
+    
+    # Example usage
+    app = MyComfyApplication()
+    if app.initialize():
+        print("Application initialized successfully!")
+        
+        # Use the loaded modules
+        utils_module = app.get_module("comfy.utils")
+        if utils_module:
+            print("Utils module is available for use")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,7 +9,6 @@ version = "0.1.2"
 license = { file = "LICENSE" }
 dependencies = [
     "asyncio",
-    "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@ce3583ad42c024b8f060d0002cbe20c265da6dc8",
     "aiortc",
     "aiohttp",
     "aiohttp_cors",
@@ -31,8 +30,11 @@ DisplayName = "ComfyStream"
 Icon = "https://raw.githubusercontent.com/livepeer/comfystream-docs/main/logo/icon-light-120px.svg" # SVG, PNG, JPG or GIF (MAX. 800x400px)
 
 [tool.setuptools]
-package-dir = {"" = "src"}
-packages = {find = {where = ["src", "nodes"]}}
+packages = ["comfystream"]
+package-dir = {"comfystream" = "src/comfystream"}
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
+
+[project.entry-points."comfyui.custom_nodes"]
+comfystream = "comfystream.nodes"

--- a/src/comfystream/__init__.py
+++ b/src/comfystream/__init__.py
@@ -3,6 +3,8 @@ from .pipeline import Pipeline
 from .server.utils import temporary_log_level
 from .server.utils import FPSMeter
 from .server.metrics import MetricsManager, StreamStatsManager
+from .comfy_loader import get_comfy_namespace
+from . import tensor_cache
 
 __all__ = [
     'ComfyStreamClient',
@@ -10,5 +12,7 @@ __all__ = [
     'temporary_log_level',
     'FPSMeter',
     'MetricsManager',
-    'StreamStatsManager'
+    'StreamStatsManager',
+    'tensor_cache',
+    'get_comfy_namespace'
 ]

--- a/src/comfystream/comfy_loader.py
+++ b/src/comfystream/comfy_loader.py
@@ -1,0 +1,258 @@
+"""
+Dedicated ComfyUI module loader with advanced features
+"""
+import sys
+import importlib
+import importlib.util
+import pkgutil
+from pathlib import Path
+from typing import Dict, Any, Optional, List
+import logging
+
+logger = logging.getLogger(__name__)
+
+class ComfyModuleLoader:
+    """Advanced ComfyUI module loader with caching and override support"""
+    
+    def __init__(self, comfyui_path: Optional[str] = None, override_utils_path: Optional[str] = None):
+        self.comfyui_path = Path(comfyui_path) if comfyui_path else self._get_default_comfyui_path()
+        self.override_utils_path = Path(override_utils_path) if override_utils_path else None
+        self._loaded_modules: Dict[str, Any] = {}
+        self._discovered_modules: List[str] = []
+        
+    def _get_default_comfyui_path(self) -> Path:
+        """Get default ComfyUI path"""
+        # Get the path relative to this comfy_loader.py file
+        # src/comfystream/comfy_loader.py -> ../../external
+        loader_file = Path(__file__).resolve()
+        comfystream_root = loader_file.parent.parent.parent  # Go up 3 levels: comfystream/ <- src/ <- comfystream/
+        external_path = comfystream_root / "external"
+        logger.debug(f"Computed external path: {external_path}")
+        return external_path
+    
+    def ensure_comfyui_available(self) -> bool:
+        """Ensure ComfyUI is available (clone if needed)"""
+        comfy_path = self.comfyui_path / "comfy"
+        if not comfy_path.exists():
+            logger.warning(f"ComfyUI comfy path does not exist: {comfy_path}")
+            return False
+        else: 
+            logger.debug(f"ComfyUI comfy path exists: {comfy_path}")
+            return True
+    
+    def setup_python_path(self) -> None:
+        """Setup Python path for ComfyUI imports"""
+        if not self.ensure_comfyui_available():
+            raise ImportError(f"ComfyUI not available at {self.comfyui_path}")
+        
+        # Add the external directory to Python path so 'import comfy' works
+        external_path = str(self.comfyui_path)
+        if external_path not in sys.path:
+            sys.path.insert(0, external_path)
+            logger.debug(f"Added {external_path} to Python path")
+        
+        # Verify that comfy can be imported
+        try:
+            # Use importlib to test the import without triggering linting errors
+            comfy_spec = importlib.util.find_spec("comfy")
+            if comfy_spec is None:
+                raise ImportError("comfy module spec not found")
+            logger.debug(f"Successfully verified comfy module spec from {external_path}")
+        except ImportError as e:
+            logger.error(f"Cannot import comfy from {external_path}: {e}")
+            # Try to add some diagnostic info
+            comfy_path = self.comfyui_path / "comfy"
+            if comfy_path.exists():
+                init_file = comfy_path / "__init__.py"
+                logger.debug(f"Comfy directory exists at {comfy_path}")
+                logger.debug(f"__init__.py exists: {init_file.exists()}")
+            raise ImportError(f"Failed to import comfy module from {external_path}: {e}")
+    
+    def discover_comfy_modules(self) -> List[str]:
+        """Dynamically discover all available comfy modules"""
+        if self._discovered_modules:
+            return self._discovered_modules
+        
+        self.setup_python_path()
+        
+        discovered = []
+        comfy_path = self.comfyui_path / "comfy"
+        
+        if not comfy_path.exists():
+            logger.error(f"Comfy path does not exist: {comfy_path}")
+            return discovered
+        
+        # Add the main comfy module
+        discovered.append("comfy")
+        
+        try:
+            import os
+            # Walk through the comfy directory to find all modules
+            for root, dirs, files in os.walk(comfy_path):
+                # Skip __pycache__ directories
+                dirs[:] = [d for d in dirs if d != "__pycache__"]
+                
+                root_path = Path(root)
+                
+                # Check if this directory has an __init__.py (making it a package)
+                if (root_path / "__init__.py").exists() and root_path != comfy_path:
+                    # Convert path to module name
+                    relative_path = root_path.relative_to(comfy_path.parent)
+                    module_name = ".".join(relative_path.parts)
+                    discovered.append(module_name)
+                
+                # Check for individual .py files
+                for file in files:
+                    if file.endswith(".py") and file != "__init__.py":
+                        file_path = root_path / file
+                        relative_path = file_path.relative_to(comfy_path.parent)
+                        # Remove .py extension and convert to module name
+                        module_parts = list(relative_path.parts[:-1]) + [relative_path.stem]
+                        module_name = ".".join(module_parts)
+                        discovered.append(module_name)
+            
+        except Exception as e:
+            logger.error(f"Error discovering comfy modules: {e}")
+        
+        self._discovered_modules = list(set(discovered))  # Remove duplicates
+        logger.info(f"Discovered {len(self._discovered_modules)} comfy modules")
+        return self._discovered_modules
+    
+    def load_comfy_module(self, module_name: str = "comfy") -> Any:
+        """Load a specific comfy module"""
+        if module_name in self._loaded_modules:
+            return self._loaded_modules[module_name]
+        
+        self.setup_python_path()
+        
+        try:
+            # Clear any cached failed imports
+            if module_name in sys.modules:
+                logger.debug(f"Module {module_name} already in sys.modules")
+            
+            module = importlib.import_module(module_name)
+            self._loaded_modules[module_name] = module
+            logger.debug(f"Loaded module: {module_name}")
+            return module
+        except ImportError as e:
+            logger.error(f"Failed to load module {module_name}: {e}")
+            # Add diagnostic information
+            logger.error(f"Python path includes: {sys.path[:3]}...")  # Show first 3 paths
+            logger.error(f"ComfyUI path: {self.comfyui_path}")
+            raise ImportError(f"Cannot load {module_name}: {e}") from e
+    
+    def load_modules_by_pattern(self, pattern: str) -> Dict[str, Any]:
+        """Load all modules matching a pattern"""
+        available_modules = self.discover_comfy_modules()
+        matching_modules = {}
+        
+        for module_name in available_modules:
+            if pattern in module_name:
+                try:
+                    module = self.load_comfy_module(module_name)
+                    matching_modules[module_name] = module
+                except ImportError as e:
+                    logger.warning(f"Could not load matching module {module_name}: {e}")
+        
+        return matching_modules
+    
+    def load_all_available_modules(self, max_modules: Optional[int] = None) -> Dict[str, Any]:
+        """Load all discovered comfy modules (with optional limit)"""
+        available_modules = self.discover_comfy_modules()
+        
+        if max_modules:
+            available_modules = available_modules[:max_modules]
+        
+        loaded_modules = {}
+        for module_name in available_modules:
+            try:
+                module = self.load_comfy_module(module_name)
+                loaded_modules[module_name] = module
+            except ImportError as e:
+                logger.warning(f"Could not load module {module_name}: {e}")
+        
+        return loaded_modules
+    
+    def load_complete_namespace(self) -> Any:
+        """Load the complete comfy namespace with all submodules"""
+        # Load main comfy module
+        comfy = self.load_comfy_module("comfy")
+        
+        # Get all available modules
+        available_modules = self.discover_comfy_modules()
+        
+        # Load essential core modules first
+        core_modules = [
+            "comfy.utils",
+            "comfy.model_management", 
+            "comfy.api",
+            "comfy.cli_args_types",
+            "comfy.client",
+            "comfy.sample",
+            "comfy.samplers",
+            "comfy.sd",
+            "comfy.model_base",
+            "comfy.graph",
+            "comfy.nodes"
+        ]
+        
+        # Load core modules
+        for module_name in core_modules:
+            if module_name in available_modules:
+                try:
+                    self.load_comfy_module(module_name)
+                except ImportError as e:
+                    logger.warning(f"Could not preload core module {module_name}: {e}")
+        
+        logger.info(f"Loaded comfy namespace with {len(self._loaded_modules)} modules")
+        return comfy
+    
+    def load_essential_modules_only(self) -> Any:
+        """Load only the most essential comfy modules for basic functionality"""
+        comfy = self.load_comfy_module("comfy")
+        
+        essential_modules = [
+            "comfy.utils",
+            "comfy.model_management",
+            "comfy.sample",
+            "comfy.samplers"
+        ]
+        
+        for module_name in essential_modules:
+            try:
+                self.load_comfy_module(module_name)
+            except ImportError as e:
+                logger.warning(f"Could not load essential module {module_name}: {e}")
+        
+        return comfy
+    
+    def get_loaded_modules(self) -> Dict[str, Any]:
+        """Get all currently loaded modules"""
+        return self._loaded_modules.copy()
+    
+    def get_available_modules(self) -> List[str]:
+        """Get list of all available modules"""
+        return self.discover_comfy_modules()
+    
+# Create a default loader instance
+default_loader = ComfyModuleLoader()
+
+def get_comfy_namespace() -> Any:
+    """Get the complete comfy namespace using the default loader"""
+    return default_loader.load_complete_namespace()
+
+def get_essential_comfy() -> Any:
+    """Get essential comfy modules only"""
+    return default_loader.load_essential_modules_only()
+
+def discover_available_modules() -> List[str]:
+    """Discover all available comfy modules"""
+    return default_loader.discover_comfy_modules()
+
+def load_specific_module(module_name: str) -> Any:
+    """Load a specific comfy module"""
+    return default_loader.load_comfy_module(module_name)
+
+def load_modules_matching(pattern: str) -> Dict[str, Any]:
+    """Load all modules matching a pattern"""
+    return default_loader.load_modules_by_pattern(pattern)

--- a/test_comfy_loader.py
+++ b/test_comfy_loader.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Test script for the enhanced ComfyUI module loader
+"""
+
+import sys
+from pathlib import Path
+
+# Add the src directory to the path so we can import comfystream
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from comfystream.comfy_loader import (
+    get_comfy_namespace,
+    get_essential_comfy,
+    discover_available_modules,
+    load_specific_module,
+    load_modules_matching,
+    default_loader
+)
+
+def test_module_discovery():
+    """Test the module discovery functionality"""
+    print("=== Testing Module Discovery ===")
+    
+    # Discover all available modules
+    modules = discover_available_modules()
+    print(f"Found {len(modules)} available modules:")
+    
+    # Show first 20 modules
+    for i, module in enumerate(modules[:20]):
+        print(f"  {i+1}. {module}")
+    
+    if len(modules) > 20:
+        print(f"  ... and {len(modules) - 20} more modules")
+    
+    return modules
+
+def test_essential_loading():
+    """Test loading essential modules"""
+    print("\n=== Testing Essential Module Loading ===")
+    
+    try:
+        comfy = get_essential_comfy()
+        print(f"Successfully loaded essential comfy modules")
+        print(f"Comfy module: {comfy}")
+        
+        # Show loaded modules
+        loaded = default_loader.get_loaded_modules()
+        print(f"Loaded {len(loaded)} modules:")
+        for module_name in loaded.keys():
+            print(f"  - {module_name}")
+            
+    except Exception as e:
+        print(f"Error loading essential modules: {e}")
+
+def test_specific_module_loading():
+    """Test loading specific modules"""
+    print("\n=== Testing Specific Module Loading ===")
+    
+    modules_to_test = [
+        "comfy.utils",
+        "comfy.model_management",
+        "comfy.sample"
+    ]
+    
+    for module_name in modules_to_test:
+        try:
+            module = load_specific_module(module_name)
+            print(f"✓ Successfully loaded {module_name}")
+            # Show some attributes if available
+            if hasattr(module, '__all__'):
+                print(f"  Available: {module.__all__[:5]}...")  # Show first 5
+            elif hasattr(module, '__dict__'):
+                attrs = [attr for attr in dir(module) if not attr.startswith('_')]
+                print(f"  Attributes: {attrs[:5]}...")  # Show first 5
+        except Exception as e:
+            print(f"✗ Failed to load {module_name}: {e}")
+
+def test_pattern_loading():
+    """Test loading modules by pattern"""
+    print("\n=== Testing Pattern-based Loading ===")
+    
+    patterns = ["api", "model", "sample"]
+    
+    for pattern in patterns:
+        try:
+            matching_modules = load_modules_matching(pattern)
+            print(f"Pattern '{pattern}' matched {len(matching_modules)} modules:")
+            for module_name in list(matching_modules.keys())[:3]:  # Show first 3
+                print(f"  - {module_name}")
+            if len(matching_modules) > 3:
+                print(f"  ... and {len(matching_modules) - 3} more")
+        except Exception as e:
+            print(f"Error loading modules matching '{pattern}': {e}")
+
+def test_complete_namespace():
+    """Test loading the complete namespace"""
+    print("\n=== Testing Complete Namespace Loading ===")
+    
+    try:
+        comfy = get_comfy_namespace()
+        print(f"Successfully loaded complete comfy namespace")
+        
+        # Show final count of loaded modules
+        loaded = default_loader.get_loaded_modules()
+        print(f"Total loaded modules: {len(loaded)}")
+        
+        # Test accessing some common attributes
+        if hasattr(comfy, 'utils'):
+            print("✓ comfy.utils is accessible")
+        if hasattr(comfy, 'model_management'):
+            print("✓ comfy.model_management is accessible")
+            
+    except Exception as e:
+        print(f"Error loading complete namespace: {e}")
+
+if __name__ == "__main__":
+    print("ComfyUI Module Loader Test")
+    print("=" * 50)
+    
+    try:
+        # Test each functionality
+        test_module_discovery()
+        test_essential_loading()
+        test_specific_module_loading()
+        test_pattern_loading()
+        test_complete_namespace()
+        
+        print("\n" + "=" * 50)
+        print("Test completed!")
+        
+    except Exception as e:
+        print(f"Test failed with error: {e}")
+        import traceback
+        traceback.print_exc()

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+Test script for ComfyStream utils and client integration
+"""
+
+import sys
+import asyncio
+from pathlib import Path
+
+# Add the src directory to the path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+import logging
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def test_utils_import():
+    """Test that utils can be imported and used"""
+    print("=== Testing Utils Import ===")
+    
+    try:
+        from comfystream.utils import (
+            convert_prompt,
+            create_load_tensor_node,
+            create_save_tensor_node,
+            create_load_audio_tensor_node,
+            create_save_audio_tensor_node,
+            PromptDictInput,
+            Configuration,
+            Comfy,
+            Prompt
+        )
+        print("✓ Successfully imported all utils components")
+        
+        # Test helper functions
+        load_node = create_load_tensor_node()
+        print(f"✓ Load tensor node: {load_node}")
+        
+        save_node = create_save_tensor_node({"test": "value"})
+        print(f"✓ Save tensor node: {save_node}")
+        
+        audio_load_node = create_load_audio_tensor_node()
+        print(f"✓ Audio load tensor node: {audio_load_node}")
+        
+        audio_save_node = create_save_audio_tensor_node({"audio": "test"})
+        print(f"✓ Audio save tensor node: {audio_save_node}")
+        
+        return True
+        
+    except Exception as e:
+        print(f"✗ Failed to import utils: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_client_import():
+    """Test that client can be imported"""
+    print("\n=== Testing Client Import ===")
+    
+    try:
+        from comfystream.client import ComfyStreamClient
+        print("✓ Successfully imported ComfyStreamClient")
+        
+        # Test creating a client instance (don't initialize it fully)
+        client = ComfyStreamClient.__new__(ComfyStreamClient)
+        print("✓ Successfully created client instance")
+        
+        return True
+        
+    except Exception as e:
+        print(f"✗ Failed to import client: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_prompt_conversion():
+    """Test prompt conversion functionality"""
+    print("\n=== Testing Prompt Conversion ===")
+    
+    try:
+        from comfystream.utils import convert_prompt, Prompt
+        
+        # Create a test prompt
+        test_prompt = {
+            "1": {
+                "class_type": "PrimaryInputLoadImage",
+                "inputs": {}
+            },
+            "2": {
+                "class_type": "PreviewImage", 
+                "inputs": {
+                    "images": ["1", 0]
+                }
+            }
+        }
+        
+        print(f"Original prompt: {test_prompt}")
+        
+        # Test prompt validation
+        validated_prompt = Prompt.validate(test_prompt)
+        print("✓ Prompt validation successful")
+        
+        # Test prompt conversion
+        converted_prompt = convert_prompt(test_prompt)
+        print(f"✓ Converted prompt: {converted_prompt}")
+        
+        return True
+        
+    except Exception as e:
+        print(f"✗ Failed prompt conversion test: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_comfy_loader_integration():
+    """Test that the ComfyUI loader works properly"""
+    print("\n=== Testing ComfyUI Loader Integration ===")
+    
+    try:
+        from comfystream.comfy_loader import (
+            get_comfy_namespace,
+            discover_available_modules,
+            load_specific_module
+        )
+        
+        # Test module discovery
+        modules = discover_available_modules()
+        print(f"✓ Discovered {len(modules)} ComfyUI modules")
+        
+        # Test loading specific modules
+        core_modules = ["comfy.utils", "comfy.model_management"]
+        for module_name in core_modules:
+            if module_name in modules:
+                try:
+                    module = load_specific_module(module_name)
+                    print(f"✓ Loaded {module_name}")
+                except Exception as e:
+                    print(f"⚠ Could not load {module_name}: {e}")
+        
+        # Test getting complete namespace
+        comfy = get_comfy_namespace()
+        print("✓ Successfully loaded ComfyUI namespace")
+        
+        return True
+        
+    except Exception as e:
+        print(f"✗ Failed ComfyUI loader integration test: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+async def test_client_initialization():
+    """Test client initialization (if possible)"""
+    print("\n=== Testing Client Initialization ===")
+    
+    try:
+        from comfystream.client import ComfyStreamClient
+        
+        # Try to create and initialize a client
+        # Note: This might fail if ComfyUI dependencies aren't fully available
+        client = ComfyStreamClient(max_workers=1)
+        print("✓ Successfully created ComfyStreamClient")
+        
+        # Test basic methods
+        if hasattr(client, 'cleanup_queues'):
+            await client.cleanup_queues()
+            print("✓ Successfully called cleanup_queues")
+        
+        return True
+        
+    except Exception as e:
+        print(f"⚠ Client initialization test failed (this may be expected): {e}")
+        # This is not necessarily a failure since ComfyUI might not be fully configured
+        return False
+
+def test_error_handling():
+    """Test error handling in utils"""
+    print("\n=== Testing Error Handling ===")
+    
+    try:
+        from comfystream.utils import convert_prompt, Prompt
+        
+        # Test invalid prompt structures
+        invalid_prompts = [
+            {},  # Empty prompt
+            {"1": {"class_type": "TestNode"}},  # Missing output
+            {  # Too many outputs
+                "1": {"class_type": "PrimaryInputLoadImage", "inputs": {}},
+                "2": {"class_type": "PreviewImage", "inputs": {}},
+                "3": {"class_type": "SaveImage", "inputs": {}}
+            }
+        ]
+        
+        for i, invalid_prompt in enumerate(invalid_prompts):
+            try:
+                convert_prompt(invalid_prompt)
+                print(f"⚠ Expected error for invalid prompt {i+1} but got none")
+            except Exception as e:
+                print(f"✓ Correctly caught error for invalid prompt {i+1}: {str(e)[:50]}...")
+        
+        return True
+        
+    except Exception as e:
+        print(f"✗ Error handling test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+async def main():
+    """Run all tests"""
+    print("ComfyStream Utils and Client Integration Test")
+    print("=" * 60)
+    
+    tests = [
+        ("Utils Import", test_utils_import),
+        ("Client Import", test_client_import), 
+        ("Prompt Conversion", test_prompt_conversion),
+        ("ComfyUI Loader Integration", test_comfy_loader_integration),
+        ("Client Initialization", test_client_initialization),
+        ("Error Handling", test_error_handling),
+    ]
+    
+    passed = 0
+    total = len(tests)
+    
+    for test_name, test_func in tests:
+        print(f"\nRunning {test_name} test...")
+        try:
+            if asyncio.iscoroutinefunction(test_func):
+                result = await test_func()
+            else:
+                result = test_func()
+            
+            if result:
+                passed += 1
+                print(f"✓ {test_name} PASSED")
+            else:
+                print(f"✗ {test_name} FAILED")
+                
+        except Exception as e:
+            print(f"✗ {test_name} FAILED with exception: {e}")
+    
+    print("\n" + "=" * 60)
+    print(f"Test Results: {passed}/{total} tests passed")
+    
+    if passed == total:
+        print("🎉 All tests passed!")
+        return True
+    else:
+        print(f"⚠ {total - passed} tests failed")
+        return False
+
+if __name__ == "__main__":
+    # Run the async main function
+    result = asyncio.run(main())
+    sys.exit(0 if result else 1)


### PR DESCRIPTION
This change dynamically imports hiddenswitch comfyui using a module loader based on import lib. By lazy loading imports in client.py, utils.py and build_trt.py, we can avoid installing hiddenswitch comfyui along with comfystream. 

This solution uses a file path import for hiddenswitch comyui package, updated to a newer commit. 

ComfyUI HiddenSwitch is upgraded from `0.3.11` to `0.3.29`
ComfyUI Native is upgraded from `0.3.27` to `0.3.29`

The dockerfile has been updated to clone hiddenswitch to `/workspace/comfystream/external`, however this docker-only step will not work for ComfyUI-Manager installs, so this logic should be moved to `comfyui_loader.py` or `__init__.py` and fully tested