### PR TITLE
fix devcontainer stuck loading in post-script

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -25,5 +25,4 @@ fi
 echo 'alias prepare_examples="/workspace/comfystream/docker/entrypoint.sh --download-models --build-engines"' >> ~/.bashrc
 echo -e "\e[32mContainer ready! Run 'prepare_examples' to download models and build engines for example workflows.\e[0m"
 
-cd /workspace/comfystream
-/bin/bash
+exit 0


### PR DESCRIPTION
These last two lines are not needed. The exit 0 ensures the devcontainer startup isn't blocked