### PR TITLE
fix: pin numpy<2.0

### DIFF
--- a/src/comfystream/scripts/constraints.txt
+++ b/src/comfystream/scripts/constraints.txt
@@ -6,3 +6,4 @@ onnx==1.17.0
 onnxruntime==1.17.0
 onnxruntime-gpu==1.20.2
 onnxmltools==1.13.0
+numpy<2.0.0


### PR DESCRIPTION
pin numpy<2.0 to resolve an issue with http-streaming package