### PR TITLE
nodes: remove sam-2 and florence-2 nodes

### DIFF
--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -43,17 +43,6 @@ nodes:
     dependencies:
       - "opencv-python"
 
-  comfyui-florence2-vision:
-    name: "ComfyUI Florence2 Vision"
-    url: "https://github.com/ad-astra-video/ComfyUI-Florence2-Vision.git"
-    type: "vision"
-   
-  comfyui-sam2-realtime:
-    name: "ComfyUI SAM2 Realtime"
-    branch: "main"
-    url: "https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git"
-    type: "vision"
-
   comfyui-load-image-url:
     name: "ComfyUI Load Image from URL"
     url: "https://github.com/tsogzark/ComfyUI-load-image-from-url.git"


### PR DESCRIPTION
This pull request removes `sam-2` and `florence-2` custom nodes from `configs/nodes.yaml` because they are unused in production currently. The sam-2 node is especially slow at compiling CUDA extensions.

### Configuration cleanup:
* Removed the `comfyui-florence2-vision` node, including its name, URL, and type information.
* Removed the `comfyui-sam2-realtime` node, including its name, branch, URL, and type information.