### PR TITLE
fix: hostname arg for ui entrypoint flag

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -30,7 +30,7 @@ stdout_logfile_maxbytes=0
 loglevel=debug
 
 [program:comfystream-ui]
-command=bash -c "npm run dev:https"
+command=bash -c "npx cross-env NEXT_PUBLIC_DEV=true next dev --experimental-https --hostname 0.0.0.0"
 directory=/workspace/comfystream/ui
 autostart=false
 autorestart=true


### PR DESCRIPTION
This change fixes an issue with the UI failing to start with the `--ui` flag

```
> cross-env NEXT_PUBLIC_DEV=true next dev --experimental-https --host 0.0.0.0

error: unknown option '--host'
(Did you mean --port?)
```