### PR TITLE
chore: Revert the remote and branch names

### DIFF
--- a/configs/nodes.yaml
+++ b/configs/nodes.yaml
@@ -2,8 +2,8 @@ nodes:
   # Core TensorRT nodes
   comfyui-tensorrt:
     name: "ComfyUI TensorRT"
-    url: "https://github.com/eliteprox/ComfyUI_TensorRT.git"
-    branch: "chore/upgrade-onnxmltools-1.14.0"
+    url: "https://github.com/yondonfu/ComfyUI_TensorRT.git"
+    branch: "quantization_with_controlnet_fixes"
     type: "tensorrt"
     dependencies:
       - "tensorrt==10.12.0.36"


### PR DESCRIPTION
This PR changes the `nodes.yaml` to use the default names that were previously changed to a private repository and branch from @eliteprox for import errors as identified in [https://github.com/yondonfu/ComfyUI_TensorRT/pull/4](https://github.com/yondonfu/ComfyUI_TensorRT/pull/4).

PR solving the issue is [https://github.com/yondonfu/ComfyUI_TensorRT/pull/5](https://github.com/yondonfu/ComfyUI_TensorRT/pull/5) merged. 