### PR TITLE
Fixes issues with importing the custom nodes and having comfyui in site-packages

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,36 +1,7 @@
-import os
-import pathlib
-
-def ensure_init_files():
-    """Create __init__.py files in comfy/ and comfy_extras/ directories if they don't exist"""
-    # Go up two levels from custom_nodes/comfystream_inside to reach ComfyUI root
-    comfy_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-    base_dirs = ['comfy', 'comfy_extras']
-    for base_dir in base_dirs:
-        base_path = os.path.join(comfy_root, base_dir)
-        if not os.path.exists(base_path):
-            continue
-            
-        # Create __init__.py in the root of base_dir first
-        root_init = os.path.join(base_path, "__init__.py")
-        if not os.path.exists(root_init):
-            with open(root_init, 'w') as f:
-                f.write("")
-                
-        # Then walk subdirectories
-        for root, dirs, files in os.walk(base_path):
-            init_path = os.path.join(root, "__init__.py")
-            if not os.path.exists(init_path):
-                with open(init_path, 'w') as f:
-                    f.write("")
-
-# Create __init__.py files in ComfyUI directories
-ensure_init_files()
-
 # Point to the directory containing our web files
 WEB_DIRECTORY = "./nodes/web/js"
 
 # Import and expose node classes
 from .nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
-__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS'] 
+__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -1,8 +1,9 @@
 """ComfyStream nodes package"""
-
-from .audio_utils import *
-from .tensor_utils import *
-from .video_stream_utils import *
+from comfy_compatibility.imports import ImportContext, SITE_PACKAGES, MAIN_PY
+with ImportContext("comfy", "comfy_extras", order=[SITE_PACKAGES, MAIN_PY]):
+    from .audio_utils import *
+    from .tensor_utils import *
+    from .video_stream_utils import *
 from .api import *
 from .web import *
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.1.4"
 license = { file = "LICENSE" }
 dependencies = [
     "asyncio",
-    "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@ce3583ad42c024b8f060d0002cbe20c265da6dc8",
+    "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git",
     "aiortc",
     "aiohttp",
     "aiohttp_cors",


### PR DESCRIPTION
This replaces https://github.com/livepeer/comfystream/pull/340

The step of populating the comfyui workspace with __init__ files is now done by hiddenswitch/comfyui
This means you can update it normally

The automated test from https://github.com/hiddenswitch/ComfyUI/blob/master/tests/issues/__test_30_comfy_workspace_conflicts.py has this result:
```
/home/administrator/Documents/appmana/.venv/bin/python /home/administrator/.local/share/JetBrains/IntelliJIdea2025.2/python-ce/helpers/pycharm/_jb_pytest_runner.py --target appmana-comfyui/src/tests/issues/__test_30_comfy_workspace_conflicts.py::test_server_starts_with_comfystream
Testing started at 10:43 PM ...
Launching pytest with arguments appmana-comfyui/src/tests/issues/__test_30_comfy_workspace_conflicts.py::test_server_starts_with_comfystream --no-header --no-summary -q in /home/administrator/Documents/appmana

============================= test session starts ==============================
collecting ... tests.issues.__test_30_comfy_workspace_conflicts <Function test_server_starts_with_comfystream>
collected 1 item

appmana-comfyui/src/tests/issues/__test_30_comfy_workspace_conflicts.py::test_server_starts_with_comfystream 

============================== 1 passed in 26.02s ==============================

--- Cloning ComfyUI ---
Running command: git clone https://github.com/comfyanonymous/ComfyUI.git /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI
--- Success: Cloning ComfyUI ---

--- Creating virtual environment with uv ---
Running command: uv venv
--- Success: Creating virtual environment with uv ---

--- Installing requirements.txt ---
Running command: . "/tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/.venv/bin/activate" && uv pip install --torch-backend=auto -r requirements.txt
--- Success: Installing requirements.txt ---

--- Installing comfystream with overrides ---
Running command: . "/tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/.venv/bin/activate" && uv pip install --torch-backend=auto git+https://github.com/doctorpangloss/comfystream.git@f2f7929def53a4853cc5a1c2774aea70775ce2ff --overrides=/tmp/pytest-of-administrator/pytest-20/comfyui_ws0/overrides.txt
--- Success: Installing comfystream with overrides ---

--- Cloning comfystream into custom_nodes ---
Running command: git clone https://github.com/doctorpangloss/comfystream.git /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/custom_nodes/comfystream
--- Success: Cloning comfystream into custom_nodes ---

--- Checking out comfystream commit f2f7929 ---
Running command: git checkout f2f7929def53a4853cc5a1c2774aea70775ce2ff
--- Success: Checking out comfystream commit f2f7929 ---

--- Finding site-packages directory ---
Running command: /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/.venv/bin/python -c import sysconfig; print(sysconfig.get_paths()['purelib'])
--- Success: Finding site-packages directory ---
--- Success: Found /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/.venv/lib/python3.12/site-packages/comfy/api/__init__.py ---

--- Starting ComfyUI Server ---

Prestartup times for custom nodes:
   0.0 seconds: /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/custom_nodes/comfystream

Checkpoint files will always be loaded safely.
Total VRAM 22563 MB, total RAM 128730 MB
pytorch version: 2.8.0+cu129
Set vram state to: NORMAL_VRAM
Device: cuda:0 NVIDIA RTX A5000 : cudaMallocAsync
Using pytorch attention
Python version: 3.12.11 (main, Aug  8 2025, 17:06:48) [Clang 20.1.4 ]
ComfyUI version: 0.3.56
****** User settings have been changed to be stored on the server instead of browser storage. ******
****** For multi-user setups add the --multi-user CLI argument to enable multiple user profiles. ******
ComfyUI frontend version: 1.25.11
[Prompt Server] web root: /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/.venv/lib/python3.12/site-packages/comfyui_frontend_package/static
Successfully imported spandrel_extra_arches: support for non commercial upscale models.
Detected extension name: comfystream
2025-09-03 15:43:50 [INFO] [root] [__init__.py:42] Detected extension name: comfystream
Setting up static route: /extensions/comfystream/static -> /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/custom_nodes/comfystream/nodes/web/static
2025-09-03 15:43:50 [INFO] [root] [__init__.py:52] Setting up static route: /extensions/comfystream/static -> /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/custom_nodes/comfystream/nodes/web/static
Added ComfyStream cache control middleware for /extensions/comfystream/static/index.html
2025-09-03 15:43:50 [INFO] [root] [__init__.py:58] Added ComfyStream cache control middleware for /extensions/comfystream/static/index.html
Initializing LocalComfyStreamServer
2025-09-03 15:43:50 [INFO] [root] [server_manager.py:37] Initializing LocalComfyStreamServer

Import times for custom nodes:
2025-09-03 15:43:50 [INFO] [root] [nodes.py:2234] 
Import times for custom nodes:
   0.0 seconds: /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/custom_nodes/websocket_image_save.py
2025-09-03 15:43:50 [INFO] [root] [nodes.py:2240]    0.0 seconds: /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/custom_nodes/websocket_image_save.py
   0.8 seconds: /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/custom_nodes/comfystream
2025-09-03 15:43:50 [INFO] [root] [nodes.py:2240]    0.8 seconds: /tmp/pytest-of-administrator/pytest-20/comfyui_ws0/ComfyUI/custom_nodes/comfystream

2025-09-03 15:43:50 [INFO] [root] [nodes.py:2241] 
No target revision found.
2025-09-03 15:43:51 [WARNING] [root] [db.py:87] No target revision found.
Starting server

2025-09-03 15:43:51 [INFO] [root] [server.py:967] Starting server

To see the GUI go to: http://127.0.0.1:8188

--- Terminating ComfyUI Server ---

--- Remaining Server Output ---
2025-09-03 15:43:51 [INFO] [root] [server.py:984] To see the GUI go to: http://127.0.0.1:8188


--- Verifying .gitignore integrity ---
--- Success: .gitignore was not modified. ---

--- Verifying Git status for untracked files ---

--- Checking git status for untracked files ---
Running command: git status --porcelain
--- Success: Checking git status for untracked files ---
--- Success: No untracked __init__.py files found. ---
PASSED
Process finished with exit code 0
```