### PR TITLE
fix launch config, patch comfyui workspace with install.py

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -75,15 +75,19 @@ Start ComfyUI:
 ```sh
 cd /workspace/ComfyUI
 conda activate comfyui
-python main.py --listen
+python main.py --listen --front-end-version Comfy-Org/ComfyUI_frontend@v1.24.2
 ```
+
+> [!NOTE]
+> The `--front-end-version Comfy-Org/ComfyUI_frontend@v1.24.2` flag is necessary because v1.24.2 is the latest version of the ComfyUI frontend that works reliably with ComfyStream.
+
 
 When using TensorRT engine enabled workflows, you should include the `---disable-cuda-malloc` flag as shown below:
 
 ```sh
 cd /workspace/ComfyUI
 conda activate comfyui
-python main.py --listen --disable-cuda-malloc
+python main.py --listen --disable-cuda-malloc --front-end-version Comfy-Org/ComfyUI_frontend@v1.24.2
 ```
 
 ### Starting ComfyStream

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "args": [
                 "--listen",
                 "--disable-cuda-malloc",
-                "--front-end-version", "Comfy-Org/ComfyUI_frontend@latest"
+                "--front-end-version", "Comfy-Org/ComfyUI_frontend@v1.24.2"
             ],
             "python": "/workspace/miniconda3/envs/comfystream/bin/python",
             "justMyCode": true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,22 +10,22 @@
             "request": "launch",
             "cwd": "/workspace/ComfyUI",
             "program": "main.py",
-            "purpose": ["debug-in-terminal"],
-            "env": {
-                "PYDEVD_DISABLE_FILE_VALIDATION": "1"
-            },
+            "console": "integratedTerminal",
             "args": [
                 "--listen",
-                "--disable-cuda-malloc"
+                "--disable-cuda-malloc",
+                "--front-end-version", "Comfy-Org/ComfyUI_frontend@latest"
             ],
-            "python": "/workspace/miniconda3/envs/comfystream/bin/python"
+            "python": "/workspace/miniconda3/envs/comfystream/bin/python",
+            "justMyCode": true
         },
         {
             "name": "Run ComfyStream",
             "type": "debugpy",
             "request": "launch",
-            "cwd": "/workspace/comfystream/server",
-            "program": "app.py",
+            "cwd": "/workspace/ComfyUI",
+            "program": "/workspace/comfystream/server/app.py",
+            "console": "integratedTerminal",
             "args": [
                 "--workspace=/workspace/ComfyUI",
                 "--media-ports=5678",
@@ -33,7 +33,8 @@
                 "--port=8889",
                 "--log-level=DEBUG",
             ],
-            "python": "/workspace/miniconda3/envs/comfystream/bin/python"
+            "python": "/workspace/miniconda3/envs/comfystream/bin/python",
+            "justMyCode": true
         },
         {
             "name": "Run ComfyStream UI (Node.js)",
@@ -44,15 +45,16 @@
             "runtimeExecutable": "npm",
             "runtimeArgs": [
                 "run",
-                "dev:https"
+                "dev"
             ],
             "serverReadyAction": {
                 "pattern": "listening on",
                 "uriFormat": "http://localhost:3000",
                 "action": "openExternally"
             }
-        },
-    ], "compounds": [
+        }
+    ],
+    "compounds": [
         {
             "name": "Run ComfyStream and UI",
             "type": "composite",

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -79,9 +79,6 @@ ENV CACHEBUST=${CACHEBUST}
 # Run setup_nodes
 RUN conda run -n comfystream --no-capture-output --cwd /workspace/comfystream python src/comfystream/scripts/setup_nodes.py --workspace /workspace/ComfyUI
 
-# Setup opencv with CUDA support
-RUN conda run -n comfystream --no-capture-output bash /workspace/comfystream/docker/entrypoint.sh --opencv-cuda
-
 RUN conda run -n comfystream --no-capture-output pip install "numpy<2.0.0"
 
 RUN conda run -n comfystream --no-capture-output pip install --no-cache-dir xformers==0.0.30 --no-deps

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -67,6 +67,9 @@ RUN conda run -n comfystream --cwd /workspace/comfystream --no-capture-output pi
 COPY ./workflows/comfyui/* /workspace/ComfyUI/user/default/workflows/
 COPY ./test/example-512x512.png /workspace/ComfyUI/input
 
+# Install ComfyUI requirements
+RUN conda run -n comfystream --no-capture-output --cwd /workspace/ComfyUI pip install -r requirements.txt --root-user-action=ignore
+
 # Install ComfyStream requirements
 RUN ln -s /workspace/comfystream /workspace/ComfyUI/custom_nodes/comfystream
 RUN conda run -n comfystream --no-capture-output --cwd /workspace/comfystream pip install -e . --root-user-action=ignore

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -67,9 +67,6 @@ RUN conda run -n comfystream --cwd /workspace/comfystream --no-capture-output pi
 COPY ./workflows/comfyui/* /workspace/ComfyUI/user/default/workflows/
 COPY ./test/example-512x512.png /workspace/ComfyUI/input
 
-# Install ComfyUI requirements
-RUN conda run -n comfystream --no-capture-output --cwd /workspace/ComfyUI pip install -r requirements.txt --root-user-action=ignore
-
 # Install ComfyStream requirements
 RUN ln -s /workspace/comfystream /workspace/ComfyUI/custom_nodes/comfystream
 RUN conda run -n comfystream --no-capture-output --cwd /workspace/comfystream pip install -e . --root-user-action=ignore

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -8,7 +8,7 @@ loglevel=info
 pidfile=/var/run/supervisord.pid
 
 [program:comfyui]
-command=bash -c "source /workspace/miniconda3/bin/activate comfystream && python main.py --listen --disable-cuda-malloc"
+command=bash -c "source /workspace/miniconda3/bin/activate comfystream && python main.py --listen --disable-cuda-malloc --front-end-version Comfy-Org/ComfyUI_frontend@v1.24.2"
 directory=/workspace/ComfyUI
 autostart=false
 autorestart=true

--- a/install.py
+++ b/install.py
@@ -89,12 +89,13 @@ if __name__ == "__main__":
                 break
             current = os.path.dirname(current)
 
+    logger.info("Installing comfystream package...")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", "."])
+
     if workspace is None:
         logger.warning("No ComfyUI workspace found. Please specify a valid workspace path to fully install")
     
     if workspace is not None:
-        logger.info("Installing comfystream package...")
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", "."])
         logger.info("Patching ComfyUI workspace...")
         auto_patch_workspace_and_restart(workspace)
     

--- a/install.py
+++ b/install.py
@@ -9,6 +9,7 @@ import tempfile
 import urllib.request
 import toml
 import zipfile
+from comfy_compatibility.workspace import auto_patch_workspace_and_restart
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
@@ -92,8 +93,8 @@ if __name__ == "__main__":
         logger.warning("No ComfyUI workspace found. Please specify a valid workspace path to fully install")
     
     if workspace is not None:
-        logger.info("Installing custom node requirements...")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", "."])
+        logger.info("Patching ComfyUI workspace...")        
+        auto_patch_workspace_and_restart(workspace)
     
     logger.info("Downloading and extracting UI files...")
     version = get_project_version(os.getcwd())

--- a/install.py
+++ b/install.py
@@ -93,7 +93,9 @@ if __name__ == "__main__":
         logger.warning("No ComfyUI workspace found. Please specify a valid workspace path to fully install")
     
     if workspace is not None:
-        logger.info("Patching ComfyUI workspace...")        
+        logger.info("Installing comfystream package...")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", "."])
+        logger.info("Patching ComfyUI workspace...")
         auto_patch_workspace_and_restart(workspace)
     
     logger.info("Downloading and extracting UI files...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.1.4"
 license = { file = "LICENSE" }
 dependencies = [
     "asyncio",
-    "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git",
+    "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@58622c7e91cb5cc2bca985d713db55e5681ff316",
     "aiortc",
     "aiohttp",
     "aiohttp_cors",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asyncio
-comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@ce3583ad42c024b8f060d0002cbe20c265da6dc8
+comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@58622c7e91cb5cc2bca985d713db55e5681ff316
 aiortc
 aiohttp
 aiohttp_cors

--- a/src/comfystream/scripts/build_trt.py
+++ b/src/comfystream/scripts/build_trt.py
@@ -19,27 +19,6 @@ if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 if COMFYUI_DIR not in sys.path:
     sys.path.insert(0, COMFYUI_DIR)
-    
-comfy_dirs = [
-    "/workspace/ComfyUI/",
-    "/workspace/ComfyUI/comfy",
-    "/workspace/ComfyUI/comfy_extras"
-]
-
-for comfy_dir in comfy_dirs:
-    init_file_path = os.path.join(comfy_dir, "__init__.py")
-
-    # Check if the __init__.py file exists
-    if not os.path.exists(init_file_path):
-        try:
-            # Create the __init__.py file
-            with open(init_file_path, "w") as init_file:
-                init_file.write("# This file ensures comfy is treated as a package\n")
-            print(f"Created __init__.py at {init_file_path}")
-        except Exception as e:
-            print(f"Error creating __init__.py: {e}")
-    else:
-        print(f"__init__.py already exists at {init_file_path}")
 
 import comfy
 import comfy.model_management


### PR DESCRIPTION
This PR fixes running comfystream in ComfyUI as a custom node by ensuring the ComfyUI workspace is patched with install.py during custom node installation. https://github.com/livepeer/comfystream/blob/0d582a9577332aa08d0501031da4f4ee8104c376/install.py#L12
https://github.com/livepeer/comfystream/blob/0d582a9577332aa08d0501031da4f4ee8104c376/install.py#L95-L97

The following additional changes were made:
- launch.json is updated to resolve issues with node loading as well as path issues
- build_trt.py was updated to remove init file patching
- Dockerfile.base was updated to remove the custom opencv installation due to runtime issues importing nodes that use it
