### PR TITLE
use pytrickle decorators

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -589,7 +589,7 @@ if __name__ == "__main__":
             comfyui_inference_log_level=args.comfyui_inference_log_level,
             warmup_workflow=args.warmup_workflow
         )
-        
+
         # Create frame skip configuration only if enabled
         frame_skip_config = None
         if args.frame_skip_enabled:
@@ -598,12 +598,8 @@ if __name__ == "__main__":
         else:
             logger.info("Frame skipping disabled")
         
-        processor = StreamProcessor(
-            video_processor=frame_processor.process_video_async,
-            audio_processor=frame_processor.process_audio_async,
-            model_loader=frame_processor.load_model,
-            param_updater=frame_processor.update_params,
-            on_stream_stop=frame_processor.on_stream_stop,
+        processor = StreamProcessor.from_handlers(
+            frame_processor,
             name="comfystream-processor",
             port=int(args.port),
             host=args.host,

--- a/server/frame_processor.py
+++ b/server/frame_processor.py
@@ -6,6 +6,7 @@ from typing import List
 import numpy as np
 from pytrickle.frame_processor import FrameProcessor
 from pytrickle.frames import VideoFrame, AudioFrame
+from pytrickle.decorators import trickle_handler
 from comfystream.pipeline import Pipeline
 from comfystream.utils import load_prompt_from_file, get_default_workflow, ComfyStreamParamsUpdateRequest
 
@@ -46,7 +47,8 @@ class ComfyStreamFrameProcessor(FrameProcessor):
         if self.pipeline and self._stream_processor:
             self.pipeline.set_text_callback(self._text_callback)
             self.pipeline.start_text_monitoring()
-    
+
+    @trickle_handler("stream_stop")
     async def on_stream_stop(self):
         """Called when stream stops - cleanup background tasks."""
         logger.info("Stream stopped, cleaning up text monitoring")
@@ -56,7 +58,7 @@ class ComfyStreamFrameProcessor(FrameProcessor):
         
         logger.info("Text monitoring cleanup completed")
     
-
+    @trickle_handler("model_loader")
     async def load_model(self, **kwargs):
         """Load model and initialize the pipeline."""
         params = {**self._load_params, **kwargs}
@@ -119,6 +121,7 @@ class ComfyStreamFrameProcessor(FrameProcessor):
         except Exception as e:
             logger.error(f"Warmup failed: {e}")
 
+    @trickle_handler("video")
     async def process_video_async(self, frame: VideoFrame) -> VideoFrame:
         """Process video frame through ComfyStream Pipeline."""
         try:
@@ -140,6 +143,7 @@ class ComfyStreamFrameProcessor(FrameProcessor):
             logger.error(f"Video processing failed: {e}")
             return frame
 
+    @trickle_handler("audio")
     async def process_audio_async(self, frame: AudioFrame) -> List[AudioFrame]:
         """Process audio frame through ComfyStream Pipeline or passthrough."""
         try:
@@ -167,6 +171,7 @@ class ComfyStreamFrameProcessor(FrameProcessor):
             logger.error(f"Audio processing failed: {e}")
             return [frame]
 
+    @trickle_handler("param_updater")
     async def update_params(self, params: dict):
         """Update processing parameters."""
         if not self.pipeline:


### PR DESCRIPTION
uses decorators from https://github.com/livepeer/pytrickle/pull/35 to 'pass' frameprocessor_methods to StreamProcessor initialization via new 'from_handlers' method ( keeps trickle backwards compatible )