### PR TITLE
fix: ensure client stop/start properly

### DIFF
--- a/src/comfystream/utils.py
+++ b/src/comfystream/utils.py
@@ -1,5 +1,5 @@
 import copy
-
+import importlib
 from typing import Dict, Any
 from comfy.api.components.schema.prompt import Prompt, PromptDictInput
 
@@ -21,6 +21,11 @@ def create_save_tensor_node(inputs: Dict[Any, Any]):
 
 
 def convert_prompt(prompt: PromptDictInput) -> Prompt:
+    try:
+        importlib.import_module("comfy.api.components.schema.prompt_node")
+    except Exception:
+        pass
+    
     # Validate the schema
     Prompt.validate(prompt)
 


### PR DESCRIPTION
This PR ensures ComfyStreamClient stops and starts properly between streams. 

This is a break-fix from the recent ComfyUI upgrade, though this change also better addresses issues like https://linear.app/livepeer/issue/INF-170/fix-comfyui-shutdown-logic