### PR TITLE
workflows: fix sample rate in audio transcription

### DIFF
--- a/workflows/comfystream/audio-transcription-api.json
+++ b/workflows/comfystream/audio-transcription-api.json
@@ -1,7 +1,10 @@
 {
   "10": {
     "inputs": {
-      "sample_rate": 16000,
+      "sample_rate": [
+        "11",
+        1
+      ],
       "transcription_interval": 2,
       "accumulation_duration": 3,
       "whisper_model": "base",


### PR DESCRIPTION
This PR fixes an issue with the sample rate being fixed, leading to incorrect sample_rate passed to the audio transcription node. 

This will produce `Non-optimal sample rate 48000Hz for Whisper (16kHz recommended)` warnings, but it is recommended to use a resample node in the workflow to properly resample as needed, arbitrarily setting it causes an issue with incoherent transcriptions