### PR TITLE
remove ai-runner gh workflow trigger

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -83,28 +83,6 @@ jobs:
           cache-from: type=registry,ref=livepeer/comfyui-base:build-cache
           cache-to: type=registry,mode=max,ref=livepeer/comfyui-base:build-cache
 
-  trigger:
-    name: Trigger ai-runner workflow
-    needs: base
-    if: ${{ github.repository == 'livepeer/comfystream' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send workflow dispatch event to ai-runner
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: "ai-runner",
-              workflow_id: "comfyui-trigger.yaml",
-              ref: "main",
-              inputs: {
-                "comfyui-base-digest": "${{ needs.base.outputs.image-digest }}",
-                "triggering-branch": "${{ github.head_ref || github.ref_name }}",
-              },
-            });
-
   comfystream:
     name: comfystream image
     needs: base


### PR DESCRIPTION
This change removed the ai-runner workflow trigger to avoid generating too many PRs on the ai-runner repository. 

With the refactored pytrickle integration, ai-runner PRs will no longer be necessary for maintaining release parity. 

The ai-runner workflow trigger can still be ran manually using workflow dispatch