### PR TITLE
Update documentation links to docs.comfystream.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repo also includes a WebRTC server and UI that uses comfystream to support 
 
 Refer to [.devcontainer/README.md](.devcontainer/README.md) to setup ComfyStream in a devcontainer using a pre-configured ComfyUI docker environment.
 
-For other installation options, refer to [Install ComfyUI and ComfyStream](https://pipelines.livepeer.org/docs/technical/install/local-testing) in the Livepeer pipelines documentation.
+For other installation options, refer to [Install ComfyUI and ComfyStream](https://docs.comfystream.org/technical/get-started/install) in the ComfyStream documentation.
 
 For additional information, refer to the remaining sections below.
 
@@ -35,7 +35,7 @@ For additional information, refer to the remaining sections below.
 
 You can quickly deploy ComfyStream using the docker image `livepeer/comfystream`
 
-Refer to the documentation at [https://pipelines.livepeer.org/docs/technical/getting-started/install-comfystream](https://pipelines.livepeer.org/docs/technical/getting-started/install-comfystream) for instructions to run locally or on a remote server.
+Refer to the documentation at [https://docs.comfystream.org/technical/get-started/install](https://docs.comfystream.org/technical/get-started/install) for instructions to run locally or on a remote server.
 
 #### RunPod
 


### PR DESCRIPTION
This pull request updates documentation links in the `README.md` file to point to the new ComfyStream documentation site instead of the previous Livepeer pipelines documentation.