### PR TITLE
chore: update opencv-cuda compilation to use python 3.12

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -27,6 +27,12 @@ RUN apt update && apt install -yqq --no-install-recommends \
     swig \
     libprotobuf-dev \
     protobuf-compiler \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libgdk-pixbuf2.0-dev \
+    libffi-dev \
+    libgirepository1.0-dev \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 #enable opengl support with nvidia gpu

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -158,7 +158,7 @@ if [ "$1" = "--opencv-cuda" ]; then
   if [ ! -f "/workspace/comfystream/opencv-cuda-release.tar.gz" ]; then
     # Download and extract OpenCV CUDA build
     DOWNLOAD_NAME="opencv-cuda-release.tar.gz"
-    wget -q -O "$DOWNLOAD_NAME" https://github.com/JJassonn69/ComfyUI-Stream-Pack/releases/download/v2/opencv-cuda-release.tar.gz
+    wget -q -O "$DOWNLOAD_NAME" https://github.com/JJassonn69/ComfyUI-Stream-Pack/releases/download/v2.1/opencv-cuda-release.tar.gz
     tar -xzf "$DOWNLOAD_NAME" -C /workspace/comfystream/
     rm "$DOWNLOAD_NAME"
   else


### PR DESCRIPTION
This change the url to point to the new release for opencv-cuda thats compiled with python 3.12 to match the comfystream python version.