### PR TITLE
fix(docker): add missing development libraries for Cairo and Pango

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -27,6 +27,12 @@ RUN apt update && apt install -yqq --no-install-recommends \
     swig \
     libprotobuf-dev \
     protobuf-compiler \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libgdk-pixbuf2.0-dev \
+    libffi-dev \
+    libgirepository1.0-dev \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 #enable opengl support with nvidia gpu


### PR DESCRIPTION
This PR fixes a node installation error that's breaking docker builds by adding missing system dependencies

link to failing builds https://github.com/livepeer/comfystream/actions/runs/18044191954/job/51350780474