### PR TITLE
feat: add ComfyUI-Manager, blacklist loading for performance

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -62,7 +62,8 @@ COPY ./src/comfystream/scripts /workspace/comfystream/src/comfystream/scripts
 COPY ./configs /workspace/comfystream/configs
 
 # Clone ComfyUI
-RUN git clone --branch v0.3.56 --depth 1 https://github.com/comfyanonymous/ComfyUI.git /workspace/ComfyUI
+RUN git clone --branch v0.3.60 --depth 1 https://github.com/comfyanonymous/ComfyUI.git /workspace/ComfyUI
+RUN git clone https://github.com/Comfy-Org/ComfyUI-Manager.git /workspace/ComfyUI/custom_nodes/ComfyUI-Manager
 
 # Copy ComfyStream files into ComfyUI
 COPY . /workspace/comfystream
@@ -75,6 +76,7 @@ COPY ./test/example-512x512.png /workspace/ComfyUI/input
 
 # Install ComfyUI requirements
 RUN conda run -n comfystream --no-capture-output --cwd /workspace/ComfyUI pip install -r requirements.txt --root-user-action=ignore
+RUN cd /workspace/ComfyUI/custom_nodes/ComfyUI-Manager && pip install -r requirements.txt
 
 # Install ComfyStream requirements
 RUN ln -s /workspace/comfystream /workspace/ComfyUI/custom_nodes/comfystream

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "asyncio",
     "pytrickle @ git+https://github.com/livepeer/pytrickle.git@de37bea74679fa5db46b656a83c9b7240fc597b6",
-    "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@58622c7e91cb5cc2bca985d713db55e5681ff316",
+    "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@e62df3a8811d8c652a195d4669f4fb27f6c9a9ba",
     "aiortc",
     "aiohttp",
     "aiohttp_cors",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asyncio
 pytrickle @ git+https://github.com/livepeer/pytrickle.git@de37bea74679fa5db46b656a83c9b7240fc597b6
-comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@58622c7e91cb5cc2bca985d713db55e5681ff316
+comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@e62df3a8811d8c652a195d4669f4fb27f6c9a9ba
 aiortc
 aiohttp
 aiohttp_cors

--- a/server/app.py
+++ b/server/app.py
@@ -574,6 +574,7 @@ async def on_startup(app: web.Application):
         gpu_only=True, 
         preview_method='none',
         comfyui_inference_log_level=app.get("comfui_inference_log_level", None),
+		blacklist_nodes=["ComfyUI-Manager"]
     )
     app["pcs"] = set()
     app["video_tracks"] = {}

--- a/server/frame_processor.py
+++ b/server/frame_processor.py
@@ -162,6 +162,7 @@ class ComfyStreamFrameProcessor(FrameProcessor):
                 gpu_only=params.get('gpu_only', True),
                 preview_method=params.get('preview_method', 'none'),
                 comfyui_inference_log_level=params.get('comfyui_inference_log_level'),
+                blacklist_nodes=["ComfyUI-Manager"]
             )
 
     async def warmup(self):


### PR DESCRIPTION
This PR adds ComfyUI-Manager to the docker build and blacklists it from loading in ComfyStreamClient based on https://github.com/hiddenswitch/ComfyUI/issues/46.

ComfyUI workspace and hs are both updated to the latest ComfyUI release [v0.3.60](https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.3.60)

This change significantly improves user experience by providing a method of installing custom nodes. Furthermore, it enables  blacklisting of specific custom_nodes at runtime which is useful for pipeline configuration