### PR TITLE
models: use taesd `safetensors` instead of `pth`

### DIFF
--- a/configs/models.yaml
+++ b/configs/models.yaml
@@ -29,19 +29,19 @@ models:
   # TAESD models
   taesd:
     name: "TAESD"
-    url: "https://raw.githubusercontent.com/madebyollin/taesd/main/taesd_decoder.pth"
-    path: "vae_approx/taesd_decoder.pth"
+    url: "https://huggingface.co/madebyollin/taesd/resolve/main/taesd_decoder.safetensors"
+    path: "vae_approx/taesd_decoder.safetensors"
     type: "vae_approx"
     extra_files:
-      - url: "https://raw.githubusercontent.com/madebyollin/taesd/main/taesd_encoder.pth"
-        path: "vae_approx/taesd_encoder.pth"
+      - url: "https://huggingface.co/madebyollin/taesd/resolve/main/taesd_encoder.safetensors"
+        path: "vae_approx/taesd_encoder.safetensors"
 
   # ControlNet models
   controlnet-depth:
     name: "ControlNet Depth"
     url: "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors/resolve/main/control_v11f1p_sd15_depth_fp16.safetensors"
     path: "controlnet/control_v11f1p_sd15_depth_fp16.safetensors"
-    type: "controlnet" 
+    type: "controlnet"
 
   controlnet-mediapipe-face:
     name: "ControlNet MediaPipe Face"


### PR DESCRIPTION
This PR updates models.yaml to download the `.safetensors` files instead of `.pth` for taesd. ComfyUI recognizes these files the same as `taesd`, so the change does not affect workflows. In my tests FPS performance was optimal ~22 FPS on 3090 with [sd15-tensorrt-api.json](https://github.com/livepeer/comfystream/blob/main/workflows/comfystream/sd15-tensorrt-api.json)

Benefits of this change:

**Performance**
- safetensors supports memory-mapped I/O, allowing partial reads without loading the entire file into RAM.
- `.pth` requires full deserialization, which is slower and more memory-intensive.
- TAESD models are small, but when batch-loading multiple encoders or running on constrained GPUs, this difference adds up

**Security**
- `.pth` files are just pickled Python objects - meaning they can execute arbitrary code when loaded
- safetensors are pure binary with no deserialization logic, so they cannot execute code. This makes them safe to load in untrusted environments, CI pipelines, or Docker containers without fear of remote code execution.