### PR TITLE
ui: fix deprecated husky install command

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write .",
-    "prepare": "cd .. && husky && husky install ui/.husky"
+    "prepare": "cd .. && husky ui/.husky"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
This pull request updates the `prepare` script in the `ui/package.json` file to simplify the Husky installation command.

* Changed the `prepare` script to use `husky ui/.husky` instead of `husky && husky install ui/.husky`, due to deprecation warning