### PR TITLE
chore(deps): bump pytrickle 0.1.4, replace deprecated pynvml with nvidia-ml-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.1.5"
 license = { file = "LICENSE" }
 dependencies = [
     "asyncio",
-    "pytrickle @ git+https://github.com/livepeer/pytrickle.git@de37bea74679fa5db46b656a83c9b7240fc597b6",
+    "pytrickle @ git+https://github.com/livepeer/pytrickle.git@v0.1.4",
     "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@e62df3a8811d8c652a195d4669f4fb27f6c9a9ba",
     "aiortc",
     "aiohttp",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asyncio
-pytrickle @ git+https://github.com/livepeer/pytrickle.git@de37bea74679fa5db46b656a83c9b7240fc597b6
+pytrickle @ git+https://github.com/livepeer/pytrickle.git@v0.1.4
 comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@e62df3a8811d8c652a195d4669f4fb27f6c9a9ba
 aiortc
 aiohttp

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -8,4 +8,4 @@ bcrypt
 rich
 # Profiler
 psutil
-pynvml
+nvidia-ml-py


### PR DESCRIPTION
This PR bumps pytrickle to version 0.1.4 which removes `pynvml` due to deprecation warning. 

This change also replaces `pynvml` in comfystream requirements with `nvidia-ml-py`