### PR TITLE
pin setuptools<81 to resolve opentelemetry warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "wheel"]
+requires = ["setuptools>=64.0.0,<81", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This change addresses a warning from `opentelemetry-sdk` package which is a dependency of comfyui:
`/workspace/miniconda3/envs/comfystream/lib/python3.12/site-packages/opentelemetry/instrumentation/dependencies.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.`

This is resolved in a newer version ([v0.49b1](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.49b1)) according to https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2871#issuecomment-2471631043), however ComfyUI installs the older version by default, so we should pin setuptools for now to avoid issues

```
Name: opentelemetry-sdk
Version: 1.27.0
Summary: OpenTelemetry Python SDK
Home-page: https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-sdk
Author: 
Author-email: OpenTelemetry Authors <cncf-opentelemetry-contributors@lists.cncf.io>
License: Apache-2.0
Location: /workspace/miniconda3/envs/comfystream/lib/python3.12/site-packages
Requires: opentelemetry-api, opentelemetry-semantic-conventions, typing-extensions
Required-by: comfyui, opentelemetry-distro, opentelemetry-exporter-otlp-proto-grpc, opentelemetry-exporter-otlp-proto-http
(comfystream) root@b7f7a703be58:/workspace/comfystream# 
```