### PR TITLE
feat(pipeline): implement pause and resume functionality for prompt execution control

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.1.6"
 license = { file = "LICENSE" }
 dependencies = [
     "asyncio",
-    "pytrickle @ git+https://github.com/livepeer/pytrickle.git@v0.1.4",
+    "pytrickle @ git+https://github.com/livepeer/pytrickle.git@bee28486ff92f4d12f1783d5466f4e702a79b811",
     "comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@e62df3a8811d8c652a195d4669f4fb27f6c9a9ba",
     "aiortc",
     "aiohttp",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asyncio
-pytrickle @ git+https://github.com/livepeer/pytrickle.git@v0.1.4
+pytrickle @ git+https://github.com/livepeer/pytrickle.git@bee28486ff92f4d12f1783d5466f4e702a79b811
 comfyui @ git+https://github.com/hiddenswitch/ComfyUI.git@e62df3a8811d8c652a195d4669f4fb27f6c9a9ba
 aiortc
 aiohttp

--- a/server/byoc.py
+++ b/server/byoc.py
@@ -187,8 +187,30 @@ def main():
             logger.error(f"Warmup failed: {e}")
             return web.json_response({"error": str(e)}, status=500)
 
+    # Add pause endpoint
+    async def pause_handler(request):
+        try:
+            # Fire-and-forget: do not await pause
+            asyncio.get_running_loop().create_task(frame_processor.pause_prompts())
+            return web.json_response({"status": "paused"})
+        except Exception as e:
+            logger.error(f"Pause failed: {e}")
+            return web.json_response({"error": str(e)}, status=500)
+
+    # Add resume endpoint
+    async def resume_handler(request):
+        try:
+            # Fire-and-forget: do not await resume
+            asyncio.get_running_loop().create_task(frame_processor.resume_prompts())
+            return web.json_response({"status": "resumed"})
+        except Exception as e:
+            logger.error(f"Resume failed: {e}")
+            return web.json_response({"error": str(e)}, status=500)
+
     # Mount at same API namespace as StreamProcessor defaults
     processor.server.add_route("POST", "/api/stream/warmup", warmup_handler)
+    processor.server.add_route("POST", "/api/stream/pause", pause_handler)
+    processor.server.add_route("POST", "/api/stream/resume", resume_handler)
     
     # Run the processor
     processor.run()

--- a/server/frame_processor.py
+++ b/server/frame_processor.py
@@ -114,10 +114,10 @@ class ComfyStreamFrameProcessor(FrameProcessor):
         self._stop_event.set()
 
         # Stop the ComfyStream client's prompt execution
-        if self.pipeline and self.pipeline.client:
+        if self.pipeline:
             logger.info("Stopping ComfyStream client prompt execution")
             try:
-                await self.pipeline.client.cleanup()
+                await self.pipeline.stop_prompts(cleanup=True)
             except Exception as e:
                 logger.error(f"Error stopping ComfyStream client: {e}")
 
@@ -271,6 +271,7 @@ class ComfyStreamFrameProcessor(FrameProcessor):
                  
             # Set prompts in pipeline
             await self.pipeline.set_prompts([converted])
+            await self.pipeline.resume_prompts()
             logger.info(f"Prompts set successfully: {list(prompts.keys())}")
             
             # Update text monitoring based on workflow capabilities

--- a/src/comfystream/pipeline.py
+++ b/src/comfystream/pipeline.py
@@ -123,6 +123,37 @@ class Pipeline:
         self._cached_modalities = None
         self._cached_io_capabilities = None
 
+    async def pause_prompts(self):
+        """Pause prompt execution loops without canceling tasks.
+        
+        Prompts remain in memory and can be resumed with resume_prompts().
+        """
+        await self.client.pause_prompts()
+
+    async def resume_prompts(self):
+        """Resume paused prompt execution loops.
+        
+        If prompts are not currently running, this will have no effect until
+        prompts are set via set_prompts().
+        """
+        await self.client.resume_prompts()
+
+    async def stop_prompts(self, cleanup: bool = False):
+        """Stop running prompts by canceling their tasks.
+        
+        Args:
+            cleanup: If True, perform full cleanup including queue clearing
+                     and client shutdown. If False, only cancel prompt tasks.
+        """
+        await self.client.stop_prompts(cleanup=cleanup)
+        
+        # Clear cached modalities and I/O capabilities when prompts are stopped
+        if cleanup:
+            self._cached_modalities = None
+            self._cached_io_capabilities = None
+            # Clear pipeline queues for full cleanup
+            await self._clear_pipeline_queues()
+
     async def put_video_frame(self, frame: av.VideoFrame):
         """Queue a video frame for processing.
         


### PR DESCRIPTION
- Updated `pyproject.toml` and `requirements.txt` to use the latest version of `pytrickle`.
- Enhanced `VideoStreamTrack` to support stopping and resuming prompts.
- Added new endpoints for pausing and resuming prompts in the server.
- Implemented pause and resume methods in `ComfyStreamClient` and `Pipeline` classes.
- Improved error handling and logging for prompt control actions.