### PR TITLE
fix(devcontainer): include constraints for pip install -e .

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,7 +5,7 @@ cd /workspace/comfystream
 
 # Install Comfystream in editable mode.
 echo -e "\e[32mInstalling Comfystream in editable mode...\e[0m"
-/workspace/miniconda3/envs/comfystream/bin/python3 -m pip install -e . --root-user-action=ignore > /dev/null
+/workspace/miniconda3/envs/comfystream/bin/python3 -m pip install -e . -c src/comfystream/scripts/constraints.txt --root-user-action=ignore > /dev/null
 
 # Install npm packages if needed
 if [ ! -d "/workspace/comfystream/ui/node_modules" ]; then


### PR DESCRIPTION
Updates post-script.sh to incluide the constraints file when installing comfystream as editable.

This change fixes broken devcontainers which report an incorrect version of numpy, which is reinstalled unintentionally when install is ran without constraints. 

Related to torch 2.7.1 and xformers, deps to be upgraded in https://github.com/livepeer/comfystream/pull/369