### PR TITLE
fix(pipeline, client): fix workspace path mapping, add `--config` flag option

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12.x'
+          python-version: '3.12'
           cache: pip
 
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.12.x'
           cache: pip
 
       - name: Install dependencies

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,7 +41,7 @@
             "name": "Run ComfyStream BYOC",
             "type": "debugpy",
             "request": "launch",
-            "cwd": "/workspace/ComfyUI",
+            "cwd": "/workspace/comfystream",
             "program": "/workspace/comfystream/server/byoc.py",
             "console": "integratedTerminal",
             "args": [

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ If you only have a subset of those UDP ports available, you can use the `--media
 python server/app.py --workspace <COMFY_WORKSPACE> --media-ports 1024,1025,...
 ```
 
+> Tip: Use `--workspace` (preferred). `--cwd` remains a compatible alias and honors `COMFYUI_CWD`.
+
 If you are running the server in a restrictive network environment where this is not possible, you will need to use a TURN server.
 
 At the moment, the server supports using Twilio's TURN servers (although it is easy to make the update to support arbitrary TURN servers):

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -29,6 +29,7 @@ WORKSPACE_STORAGE="/app/storage"
 COMFYUI_DIR="/workspace/ComfyUI"
 MODELS_DIR="$COMFYUI_DIR/models"
 OUTPUT_DIR="$COMFYUI_DIR/output"
+export COMFYUI_CWD="$COMFYUI_DIR"
 
 # Initialize variables to track which services to start
 START_COMFYUI=false

--- a/install.py
+++ b/install.py
@@ -74,8 +74,10 @@ def download_and_extract_ui_files(version: str):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Install custom node requirements")
     parser.add_argument(
+        "--cwd",
         "--workspace",
-        default=os.environ.get("COMFY_UI_WORKSPACE", None),
+        dest="workspace",
+        default=os.environ.get("COMFYUI_CWD"),
         required=False,
         help="Set Comfy workspace",
     )
@@ -99,6 +101,9 @@ if __name__ == "__main__":
                 logger.info(f"Found ComfyUI workspace at: {workspace}")
                 break
             current = os.path.dirname(current)
+
+    if workspace is not None:
+        os.environ.setdefault("COMFYUI_CWD", workspace)
 
     logger.info("Installing comfystream package...")
     subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", "."])

--- a/server/frame_processor.py
+++ b/server/frame_processor.py
@@ -259,16 +259,23 @@ class ComfyStreamFrameProcessor(FrameProcessor):
         params = {**self._load_params, **kwargs}
 
         if self.pipeline is None:
+            comfy_kwargs: Dict[str, Any] = {
+                "cwd": params.get("workspace", os.getcwd()),
+                "disable_cuda_malloc": params.get("disable_cuda_malloc", True),
+                "gpu_only": params.get("gpu_only", True),
+                "preview_method": params.get("preview_method", "none"),
+                "logging_level": params.get("logging_level", "INFO"),
+                "blacklist_custom_nodes": ["ComfyUI-Manager"],
+            }
+
+            # If a ComfyUI config file is provided, prefer it and pass it through.
+            if params.get("config"):
+                comfy_kwargs = {"config": params["config"]}
+
             self.pipeline = Pipeline(
                 width=int(params.get("width", 512)),
                 height=int(params.get("height", 512)),
-                cwd=params.get("workspace", os.getcwd()),
-                disable_cuda_malloc=params.get("disable_cuda_malloc", True),
-                gpu_only=params.get("gpu_only", True),
-                preview_method=params.get("preview_method", "none"),
-                comfyui_inference_log_level=params.get("comfyui_inference_log_level", "INFO"),
-                logging_level=params.get("comfyui_inference_log_level", "INFO"),
-                blacklist_custom_nodes=["ComfyUI-Manager"],
+                **comfy_kwargs,
             )
             await self.pipeline.initialize()
 

--- a/src/comfystream/__init__.py
+++ b/src/comfystream/__init__.py
@@ -1,9 +1,12 @@
-from .client import ComfyStreamClient
-from .exceptions import ComfyStreamAudioBufferError, ComfyStreamInputTimeoutError
-from .pipeline import Pipeline
-from .pipeline_state import PipelineState, PipelineStateManager
-from .server.metrics import MetricsManager, StreamStatsManager
-from .server.utils import FPSMeter, temporary_log_level
+from comfy_compatibility.imports import MAIN_PY, SITE_PACKAGES, ImportContext
+
+with ImportContext("comfy", "comfy_extras", "comfy.vendor", order=[SITE_PACKAGES, MAIN_PY]):
+    from .client import ComfyStreamClient
+    from .exceptions import ComfyStreamAudioBufferError, ComfyStreamInputTimeoutError
+    from .pipeline import Pipeline
+    from .pipeline_state import PipelineState, PipelineStateManager
+    from .server.metrics import MetricsManager, StreamStatsManager
+    from .server.utils import FPSMeter, temporary_log_level
 
 __all__ = [
     "ComfyStreamClient",

--- a/src/comfystream/scripts/README.md
+++ b/src/comfystream/scripts/README.md
@@ -14,15 +14,18 @@
 
 From the repository root:
 
-> The `--workspace` flag is optional and will default to `$COMFY_UI_WORKSPACE` or `~/comfyui`.
+> The `--workspace` flag is optional and will default to `$COMFYUI_CWD` or `~/comfyui`.
 
 ### Install custom nodes
+
 ```bash
 python src/comfystream/scripts/setup_nodes.py --workspace /path/to/comfyui
 ```
+
 > The optional flag `--pull-branches` can be used to ensure the latest git changes are pulled for any custom nodes defined with a `branch` in nodes.yaml
 
 ### Download models and compile tensorrt engines
+
 ```bash
 python src/comfystream/scripts/setup_models.py --workspace /path/to/comfyui
 ```
@@ -42,7 +45,7 @@ nodes:
       - "tensorrt"
 ```
 
-> The `branch` property can be substituted with a SHA-256 commit hash for pinning custom node versions 
+> The `branch` property can be substituted with a SHA-256 commit hash for pinning custom node versions
 
 ### Models (models.yaml)
 
@@ -70,6 +73,6 @@ workspace/
 
 ## Environment Variables
 
-- `COMFY_UI_WORKSPACE`: Base directory for installation
+- `COMFYUI_CWD`: Base directory for installation
 - `PYTHONPATH`: Defaults to workspace directory
 - `CUSTOM_NODES_PATH`: Custom nodes directory

--- a/src/comfystream/scripts/setup_models.py
+++ b/src/comfystream/scripts/setup_models.py
@@ -11,9 +11,11 @@ from utils import get_config_path, load_model_config
 def parse_args():
     parser = argparse.ArgumentParser(description="Setup ComfyUI models")
     parser.add_argument(
+        "--cwd",
         "--workspace",
-        default=os.environ.get("COMFY_UI_WORKSPACE", os.path.expanduser("~/comfyui")),
-        help="ComfyUI workspace directory (default: ~/comfyui or $COMFY_UI_WORKSPACE)",
+        dest="workspace",
+        default=os.environ.get("COMFYUI_CWD", os.path.expanduser("~/comfyui")),
+        help="ComfyUI workspace directory (default: ~/comfyui or $COMFYUI_CWD)",
     )
     return parser.parse_args()
 

--- a/src/comfystream/scripts/setup_nodes.py
+++ b/src/comfystream/scripts/setup_nodes.py
@@ -11,9 +11,11 @@ from utils import get_config_path, load_model_config
 def parse_args():
     parser = argparse.ArgumentParser(description="Setup ComfyUI nodes and models")
     parser.add_argument(
+        "--cwd",
         "--workspace",
-        default=os.environ.get("COMFY_UI_WORKSPACE", Path("~/comfyui").expanduser()),
-        help="ComfyUI workspace directory (default: ~/comfyui or $COMFY_UI_WORKSPACE)",
+        dest="workspace",
+        default=os.environ.get("COMFYUI_CWD", Path("~/comfyui").expanduser()),
+        help="ComfyUI workspace directory (default: ~/comfyui or $COMFYUI_CWD)",
     )
     parser.add_argument(
         "--pull-branches",
@@ -25,7 +27,7 @@ def parse_args():
 
 
 def setup_environment(workspace_dir):
-    os.environ["COMFY_UI_WORKSPACE"] = str(workspace_dir)
+    os.environ["COMFYUI_CWD"] = str(workspace_dir)
     os.environ["PYTHONPATH"] = str(workspace_dir)
     os.environ["CUSTOM_NODES_PATH"] = str(workspace_dir / "custom_nodes")
 


### PR DESCRIPTION
This change fixes an issue with ComfyStream unable to run from a directory other than ComfyUI. It also ensures that the installed ComfyUI package is used instead of the ComfyUI workspace, fixing compatibility that was broken in a previous change

This change also adds a `--config` flag option for passing command line args to configure the `ComfyStreamClient` (ComfyUI) instance with any flag provided here https://github.com/hiddenswitch/ComfyUI?tab=readme-ov-file#configuration-file

Details of changes
- fix `--workspace` flag so ComfyStream can launch from any directory while mapping to the correct ComfyUI cwd.
- Pass the workspace/CWD and logging settings cleanly through server args → pipeline → ComfyStreamClient so ComfyUI’s configuration is honored.
- Add config passthrough support: when a ComfyUI config file is provided, forward it directly and skip overriding flags to match ComfyUI’s precedence rules.
- Ensure ComfyUI packages load correctly via the client initialization (__init__.py/ComfyStreamClient), removing legacy env handling and relying on proper cwd/config inputs.
- Update Docker, supervisord, launch configs, and docs to use the unified workspace flag and defaults.