### PR TITLE
chore(ci): move tests back to github runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,8 +56,7 @@ jobs:
 
   test:
     name: Run Tests
-    runs-on: [self-hosted, linux, amd64]
-    # self-hosted runner provides enough disk space for the full test suite
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -69,7 +68,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: pip
 
       - name: Install dependencies


### PR DESCRIPTION
self-hosted runner is missing needed python distribution, moving back to github for now