### PR TITLE
Refactor: Update model paths, node repo, and StreamDiffusion engine build logic

### DIFF
--- a/configs/models-ipadapter.yaml
+++ b/configs/models-ipadapter.yaml
@@ -30,7 +30,7 @@ models:
   PixelArtRedmond15V-PixelArt-PIXARFK.safetensors:
     name: "PixelArtRedmond15V-PixelArt-PIXARFK"
     url: "https://huggingface.co/artificialguybr/pixelartredmond-1-5v-pixel-art-loras-for-sd-1-5/resolve/ab43d9e2cf8c9240189f01e9cdc4ca341362500c/PixelArtRedmond15V-PixelArt-PIXARFK.safetensors"
-    path: "loras/SD1.5/PixelArtRedmond15V-PixelArt-PIXARFK.safetensors"
+    path: "loras/SD1.5/PixelArt.safetensors"
     type: "lora"
 
   # TAESD for fast VAE
@@ -42,4 +42,3 @@ models:
     extra_files:
       - url: "https://huggingface.co/madebyollin/taesd/resolve/main/taesd_encoder.safetensors"
         path: "vae_approx/taesd_encoder.safetensors"
-

--- a/configs/nodes-streamdiffusion.yaml
+++ b/configs/nodes-streamdiffusion.yaml
@@ -10,7 +10,7 @@ nodes:
 
   comfyui-streamdiffusion:
     name: "ComfyUI StreamDiffusion"
-    url: "https://github.com/RUFFY-369/ComfyUI-StreamDiffusion"
+    url: "https://github.com/muxionlabs/ComfyUI-StreamDiffusion"
     branch: "main"
     type: "tensorrt"
 
@@ -34,4 +34,3 @@ nodes:
     name: "rgthree Comfy"
     url: "https://github.com/rgthree/rgthree-comfy.git"
     type: "utility"
-

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -138,23 +138,17 @@ if [ "$1" = "--build-engines" ]; then
     echo "Engines for FasterLivePortrait already exists, skipping..."
   fi
 
-  # Build Engine for StreamDiffusion
-  if [ ! -f "$TENSORRT_DIR/StreamDiffusion-engines/stabilityai/sd-turbo--lcm_lora-True--tiny_vae-True--max_batch-3--min_batch-3--mode-img2img/unet.engine.opt.onnx" ]; then
-    cd /workspace/ComfyUI/custom_nodes/ComfyUI-StreamDiffusion
-    MODELS="stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1"
-    TIMESTEPS="3"
-    for model in $MODELS; do
-      for timestep in $TIMESTEPS; do
-        echo "Building model=$model with timestep=$timestep"
-        python build_tensorrt.py \
-          --model-id "$model" \
-          --timesteps "$timestep" \
-          --engine-dir $TENSORRT_DIR/StreamDiffusion-engines
-      done
-    done
-  else
-    echo "Engine for StreamDiffusion already exists, skipping..."
-  fi
+  # Build Engine for StreamDiffusion using trt script and config
+  ENGINE_SCRIPT="/workspace/ComfyUI/custom_nodes/ComfyUI-StreamDiffusion/scripts/build_tensorrt_engines.py"
+  CONFIGS=(
+    "/workspace/ComfyUI/custom_nodes/ComfyUI-StreamDiffusion/configs/sd15_singlecontrol.yaml"
+    "/workspace/ComfyUI/custom_nodes/ComfyUI-StreamDiffusion/configs/sdturbo_multicontrol.yaml"
+  )
+  cd /workspace/ComfyUI/custom_nodes/ComfyUI-StreamDiffusion/scripts
+  for ENGINE_CONFIG in "${CONFIGS[@]}"; do
+    echo "Building StreamDiffusion TensorRT engines using config: $ENGINE_CONFIG"
+    python "$ENGINE_SCRIPT" --config "$ENGINE_CONFIG"
+  done
   shift
 fi
 


### PR DESCRIPTION
- Updated `models-ipadapter.yaml` to save the `PixelArtRedmond15V-PixelArt-PIXARFK` model as `PixelArt.safetensors` for consistency and easier referencing.
- Changed the StreamDiffusion node repository URL in `nodes-streamdiffusion.yaml `to point to `muxionlabs/ComfyUI-StreamDiffusion`.
- Refactored `entrypoint.sh` to use the new config-driven StreamDiffusion engine build script and ensured all required engines are built using the provided YAML configs in SD repo

Changes made on top of PR #488 