### PR TITLE
fix(dockerfile): Fix cudnn library mismatch error for audio transcription

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ dependencies = [
     "toml",
     "twilio",
     "prometheus_client",
-    "librosa",
-    "mediapipe==0.10.15"
+    "librosa"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ toml
 twilio
 prometheus_client
 librosa
-mediapipe==0.10.15


### PR DESCRIPTION
This change resolves an issue with audio transcription workflows failing due to two mismatched versions of cudnn installed within the base docker image

- Changed the base image in `Dockerfile.base` and `Dockerfile.opencv` from `nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04` to `nvidia/cuda:12.8.1-devel-ubuntu22.04`.
- Added `LD_LIBRARY_PATH` environment variable to the base Dockerfile to point to the correct library version
- Cleaned up unnecessary cuDNN files in the base Dockerfile to prevent mismatched link from getting into path again


Tested as BYOC container with audio transcription, fresh engine builds and a successful SD1.5 workflow run